### PR TITLE
Feat/linear

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,5 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "numpy>=2.2.4",
+    "pytest>=8.3.5",
 ]

--- a/src/layers/linear.py
+++ b/src/layers/linear.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 import numpy as np
 
-from .base import BaseLayer
+from src.layers.base import BaseLayer
 
 
 class Linear(BaseLayer):

--- a/src/layers/linear.py
+++ b/src/layers/linear.py
@@ -11,7 +11,11 @@ class Linear(BaseLayer):
     """
 
     def __init__(
-        self, input_dim: int, output_dim: int, seed: Optional[int] = None
+        self,
+        input_dim: int,
+        output_dim: int,
+        use_bias: bool = True,
+        seed: Optional[int] = None,
     ) -> None:
         """
         Initializes Linear layer.
@@ -36,13 +40,21 @@ class Linear(BaseLayer):
 
         self.input_dim = input_dim
         self.output_dim = output_dim
+        self.use_bias = use_bias
 
         # He initialization for weights
         self.W = rng.standard_normal((input_dim, output_dim)) * np.sqrt(2.0 / input_dim)
-        self.b = np.zeros(output_dim)
+
+        # initialize bias to zero if use_bias set to true
+        if use_bias:
+            self.b = np.zeros(output_dim)
+        else:
+            self.b = None
 
         # Cache for backward pass
         self._input_cache = None
+        # self.dW = None
+        # self.db = None
 
     def forward(self, x: np.ndarray, **kwargs: Any) -> np.ndarray:
         """
@@ -55,10 +67,20 @@ class Linear(BaseLayer):
         Returns:
             np.ndarray: Output data.
         """
+        if x.shape[-1] != self.input_dim:
+            raise ValueError(
+                f"Expected input shape with last dimension {self.input_dim}, "
+                f"but got {x.shape[-1]}"
+            )
         # store input for backward pass
         self._input_cache = x
 
-        return x @ self.W + self.b
+        output = x @ self.W
+        # if use_bias is True, add bias
+        if self.use_bias:
+            assert self.b is not None, "Bias should be initialized to zero"
+            output = output + self.b
+        return output
 
     def get_parameters(self) -> Dict[str, np.ndarray]:
         """
@@ -67,7 +89,11 @@ class Linear(BaseLayer):
         Returns:
             Dict[str, np.ndarray]: Dictionary of parameters.
         """
-        return {"W": self.W, "b": self.b}
+        params = {"W": self.W}
+        if self.use_bias:
+            assert self.b is not None, "Bias is enabled but not initialized"
+            params["b"] = self.b
+        return params
 
     def set_parameters(self, params: Dict[str, np.ndarray]) -> None:
         """
@@ -76,27 +102,46 @@ class Linear(BaseLayer):
         Parameters:
             params (Dict[str, np.ndarray]): Dictionary of parameters.
         """
+        # Set weights
         if "W" in params:
+            # Validate shape of W
             if params["W"].shape != (self.input_dim, self.output_dim):
                 raise ValueError(
                     f"Expected W shape {(self.input_dim, self.output_dim)}, "
                     f"but got {params['W'].shape}"
                 )
             self.W = params["W"]
-        if "b" in params:
-            if params["b"].shape != (self.output_dim,):
+        else:
+            raise ValueError("Weight parameter 'W' missing in params dictionary.")
+
+        # Set bias (if applicable)
+        if self.use_bias:
+            if "b" in params:
+                # Validate shape of b
+                if params["b"].shape != (self.output_dim,):
+                    raise ValueError(
+                        f"Expected b shape {(self.output_dim,)}, "
+                        f"but got {params['b'].shape}"
+                    )
+                self.b = params["b"]
+            else:
                 raise ValueError(
-                    f"Expected b shape {(self.output_dim,)}, "
-                    f"but got {params['b'].shape}"
+                    "Bias parameter 'b' missing in params dictionary, but use_bias is True."
                 )
-            self.b = params["b"]
+        else:
+            # If bias is not used, ensure 'b' is not provided or set self.b to None
+            if "b" in params:
+                print(
+                    "Warning: Provided bias 'b' in params when use_bias is False. Ignoring."
+                )
+            self.b = None
 
     # def backward(self, grad_output: np.ndarray) -> np.ndarray:
     #     """
     #     Computes gradients w.r.t. inputs and parameters.
 
     #     Parameters:
-    #         grad_outputs (np.ndarray): Gradient of the loss w.r.t. the output of this layer.
+    #         grad_output (np.ndarray): Gradient of the loss w.r.t. the output of this layer.
 
     #     Returns:
     #         np.ndarray: Gradient of the loss w.r.t. the input of this layer.
@@ -104,9 +149,44 @@ class Linear(BaseLayer):
     #     if self._input_cache is None:
     #         raise ValueError("No input cache found. Forward pass must be called first.")
 
-    #     # Compute gradients w.r.t. parameters (weights and bias)
-    #     self.dW = self._input_cache.T @ grad_output
-    #     self.db = np.sum(grad_output, axis=0)
+    #     # Shape: (N, ..., input_dim)
+    #     x = self._input_cache
+
+    #     # Validate shape of grad_output
+    #     if grad_output.shape[-1] != self.output_dim:
+    #         raise ValueError(
+    #             f"Expected grad_output shape with last dimension {self.output_dim}, "
+    #             f"but got {grad_output.shape[-1]}"
+    #         )
+    #     # Validate leading dimensions
+    #     if x.shape[:-1] != grad_output.shape[:-1]:
+    #         raise ValueError(
+    #             f"Leading dimensions of grad_output {grad_output.shape[:-1]} "
+    #             f"do not match cached input's leading dimensions {x.shape[:-1]}."
+    #         )
+
     #     # Gradient w.r.t. input
-    #     grad_inputs = grad_output @ self.W.T
-    #     return grad_inputs
+    #     grad_input = grad_output @ self.W.T
+
+    #     # Compute gradients w.r.t. weights
+    #     # calculate total number of samples (e.g., (batch_size, input_dim) -> batch_size, (batch_size, seq_len, input_dim) -> batch_size * seq_len)
+    #     num_samples = np.prod(x.shape[:-1])
+    #     x_reshaped = x.reshape(num_samples, self.input_dim)
+    #     grad_output_reshaped = grad_output.reshape(num_samples, self.output_dim)
+    #     self.dW = x_reshaped.T @ grad_output_reshaped
+
+    #     if self.use_bias:
+    #         assert self.b is not None, "Bias should be initialized to zero"
+    #         # Gradient w.r.t. bias
+    #         # sum grad output along all axes except last one (e.g., (0,) for 2D, (0, 1) for 3D)
+    #         sum_axes = tuple(range(grad_output.ndim - 1))
+    #         self.db = np.sum(grad_output, axis=sum_axes)
+    #         # Ensure calculated db has the correct shape (D_out,)
+    #         assert self.db.shape == (self.output_dim,), (
+    #             f"Calculated db shape {self.db.shape} doesn't match expected {(self.output_dim,)}"
+    #         )
+    #     else:
+    #         # If no bias, set db to None
+    #         self.db = None
+
+    #     return grad_input

--- a/src/layers/linear.py
+++ b/src/layers/linear.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import numpy as np
 
@@ -10,20 +10,35 @@ class Linear(BaseLayer):
     Standard fully connected linear layer.
     """
 
-    def __init__(self, input_dim: int, output_dim: int) -> None:
+    def __init__(
+        self, input_dim: int, output_dim: int, seed: Optional[int] = None
+    ) -> None:
         """
         Initializes Linear layer.
 
         Parameters:
             input_dim (int): Number of input features.
             output_dim (int): Number of output features.
+            seed (Optional[int]): Seed for weight initialization.
         """
         super().__init__()
+
+        if input_dim <= 0 or output_dim <= 0:
+            raise ValueError("Input and output dimensions must be positive integers.")
+
+        if seed is None:
+            rng = np.random.default_rng()
+        else:
+            if not isinstance(seed, int):
+                raise ValueError("Seed must be an integer.")
+            # Random number generator with a seed for reproducibility
+            rng = np.random.default_rng(seed)
+
         self.input_dim = input_dim
         self.output_dim = output_dim
 
         # He initialization for weights
-        self.W = np.random.randn(input_dim, output_dim) * np.sqrt(2.0 / self.input_dim)
+        self.W = rng.standard_normal((input_dim, output_dim)) * np.sqrt(2.0 / input_dim)
         self.b = np.zeros(output_dim)
 
         # Cache for backward pass
@@ -65,3 +80,23 @@ class Linear(BaseLayer):
             self.W = params["W"]
         if "b" in params:
             self.b = params["b"]
+
+    # def backward(self, grad_output: np.ndarray) -> np.ndarray:
+    #     """
+    #     Computes gradients w.r.t. inputs and parameters.
+
+    #     Parameters:
+    #         grad_outputs (np.ndarray): Gradient of the loss w.r.t. the output of this layer.
+
+    #     Returns:
+    #         np.ndarray: Gradient of the loss w.r.t. the input of this layer.
+    #     """
+    #     if self._input_cache is None:
+    #         raise ValueError("No input cache found. Forward pass must be called first.")
+
+    #     # Compute gradients w.r.t. parameters (weights and bias)
+    #     self.dW = self._input_cache.T @ grad_output
+    #     self.db = np.sum(grad_output, axis=0)
+    #     # Gradient w.r.t. input
+    #     grad_inputs = grad_output @ self.W.T
+    #     return grad_inputs

--- a/src/layers/linear.py
+++ b/src/layers/linear.py
@@ -77,8 +77,18 @@ class Linear(BaseLayer):
             params (Dict[str, np.ndarray]): Dictionary of parameters.
         """
         if "W" in params:
+            if params["W"].shape != (self.input_dim, self.output_dim):
+                raise ValueError(
+                    f"Expected W shape {(self.input_dim, self.output_dim)}, "
+                    f"but got {params['W'].shape}"
+                )
             self.W = params["W"]
         if "b" in params:
+            if params["b"].shape != (self.output_dim,):
+                raise ValueError(
+                    f"Expected b shape {(self.output_dim,)}, "
+                    f"but got {params['b'].shape}"
+                )
             self.b = params["b"]
 
     # def backward(self, grad_output: np.ndarray) -> np.ndarray:

--- a/src/layers/linear.py
+++ b/src/layers/linear.py
@@ -1,0 +1,67 @@
+from typing import Any, Dict
+
+import numpy as np
+
+from .base import BaseLayer
+
+
+class Linear(BaseLayer):
+    """
+    Standard fully connected linear layer.
+    """
+
+    def __init__(self, input_dim: int, output_dim: int) -> None:
+        """
+        Initializes Linear layer.
+
+        Parameters:
+            input_dim (int): Number of input features.
+            output_dim (int): Number of output features.
+        """
+        super().__init__()
+        self.input_dim = input_dim
+        self.output_dim = output_dim
+
+        # He initialization for weights
+        self.W = np.random.randn(input_dim, output_dim) * np.sqrt(2.0 / self.input_dim)
+        self.b = np.zeros(output_dim)
+
+        # Cache for backward pass
+        self._input_cache = None
+
+    def forward(self, x: np.ndarray, **kwargs: Any) -> np.ndarray:
+        """
+        Forward pass through the layer.
+
+        Parameters:
+            x (np.ndarray): Input data.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+            np.ndarray: Output data.
+        """
+        # store input for backward pass
+        self._input_cache = x
+
+        return x @ self.W + self.b
+
+    def get_parameters(self) -> Dict[str, np.ndarray]:
+        """
+        Get the parameters of the layer.
+
+        Returns:
+            Dict[str, np.ndarray]: Dictionary of parameters.
+        """
+        return {"W": self.W, "b": self.b}
+
+    def set_parameters(self, params: Dict[str, np.ndarray]) -> None:
+        """
+        Set the parameters of the layer.
+
+        Parameters:
+            params (Dict[str, np.ndarray]): Dictionary of parameters.
+        """
+        if "W" in params:
+            self.W = params["W"]
+        if "b" in params:
+            self.b = params["b"]

--- a/tests/layers/test_linear.py
+++ b/tests/layers/test_linear.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy import ndarray
 
 from src.layers.linear import Linear
 
@@ -10,24 +11,24 @@ def layer_config() -> dict[str, int]:
 
 
 @pytest.fixture
-def linear_layer(layer_config):
+def linear_layer(layer_config: dict[str, int]) -> Linear:
     return Linear(layer_config["input_dim"], layer_config["output_dim"])
 
 
 @pytest.fixture
-def sample_input_2d(layer_config) -> np.ndarray:
+def sample_input_2d(layer_config: dict[str, int]) -> np.ndarray:
     batch_size = 4
     return np.random.randn(batch_size, layer_config["input_dim"])
 
 
 @pytest.fixture
-def sample_input_3d(layer_config) -> np.ndarray:
+def sample_input_3d(layer_config: dict[str, int]) -> np.ndarray:
     batch_size = 4
     seq_len = 8
     return np.random.randn(batch_size, seq_len, layer_config["input_dim"])
 
 
-def test_linear_init(linear_layer, layer_config):
+def test_linear_init(linear_layer: Linear, layer_config: dict[str, int]) -> None:
     """Tests layer initialiaztion: dimensions and default mode."""
     input_dim = layer_config["input_dim"]
     output_dim = layer_config["output_dim"]
@@ -54,7 +55,7 @@ def test_linear_init(linear_layer, layer_config):
     assert np.all(linear_layer.b == 0), "Bias b should be initialized to zero"
 
 
-def test_linear_get_parameters(linear_layer):
+def test_linear_get_parameters(linear_layer: Linear) -> None:
     """Tests get_parameters method."""
     params = linear_layer.get_parameters()
 
@@ -71,7 +72,9 @@ def test_linear_get_parameters(linear_layer):
     assert len(params) == 2, "Expected 2 parameters (W and b)"
 
 
-def test_linear_forward_shape_2d(linear_layer, sample_input_2d):
+def test_linear_forward_shape_2d(
+    linear_layer: Linear, sample_input_2d: ndarray
+) -> None:
     """Tests forward method with 2D input."""
     output = linear_layer(sample_input_2d)
     batch_size = sample_input_2d.shape[0]
@@ -82,7 +85,9 @@ def test_linear_forward_shape_2d(linear_layer, sample_input_2d):
     )
 
 
-def test_linear_forward_shape_3d(linear_layer, sample_input_3d):
+def test_linear_forward_shape_3d(
+    linear_layer: Linear, sample_input_3d: ndarray
+) -> None:
     """Tests forward method with 3D input."""
     output = linear_layer(sample_input_3d)
     batch_size, seq_len = sample_input_3d.shape[0], sample_input_3d.shape[1]
@@ -93,7 +98,9 @@ def test_linear_forward_shape_3d(linear_layer, sample_input_3d):
     )
 
 
-def test_linear_forward_computation(linear_layer, layer_config):
+def test_linear_forward_computation(
+    linear_layer: Linear, layer_config: dict[str, int]
+) -> None:
     """Tests forward pass computation with set weights and input."""
     input_dim = layer_config["input_dim"]
     output_dim = layer_config["output_dim"]

--- a/tests/layers/test_linear.py
+++ b/tests/layers/test_linear.py
@@ -29,7 +29,7 @@ def sample_input_3d(layer_config: dict[str, int]) -> np.ndarray:
 
 
 def test_linear_init(linear_layer: Linear, layer_config: dict[str, int]) -> None:
-    """Tests layer initialiaztion: dimensions and default mode."""
+    """Tests initialization of linear layer: shape, dimensions ."""
     input_dim = layer_config["input_dim"]
     output_dim = layer_config["output_dim"]
 
@@ -132,4 +132,53 @@ def test_linear_forward_computation(
         rtol=1e-6,
         atol=1e-6,
         err_msg="Forward pass computation mismatch",
+    )
+
+
+def test_linears_same_seed(layer_config: dict[str, int]) -> None:
+    """Tests initialization of two linear layers with same seed."""
+    input_dim = layer_config["input_dim"]
+    output_dim = layer_config["output_dim"]
+
+    seed = 42
+
+    layer1 = Linear(input_dim, output_dim, seed=seed)
+    layer2 = Linear(input_dim, output_dim, seed=seed)
+
+    # Check if weights are initialized equally
+    assert np.array_equal(layer1.W, layer2.W), "Weights W should be equal"
+    assert np.array_equal(layer1.b, layer2.b), (
+        "Bias b should be equal, as it is initialized to zero"
+    )
+
+
+def test_linears_diff_seed(layer_config: dict[str, int]) -> None:
+    """Tests initialization of two linear layers with different seed."""
+    input_dim = layer_config["input_dim"]
+    output_dim = layer_config["output_dim"]
+
+    seed = 42
+
+    layer1 = Linear(input_dim, output_dim, seed=seed)
+    layer2 = Linear(input_dim, output_dim, seed=seed + 1)
+
+    # Check if weights are initialized differently
+    assert not np.array_equal(layer1.W, layer2.W), "Weights W should be different"
+    assert np.array_equal(layer1.b, layer2.b), (
+        "Bias b should be equal, as it is initialized to zero"
+    )
+
+
+def test_linears_no_seed(layer_config: dict[str, int]) -> None:
+    """Tests initialization of two linear layers with no seed (should be different)."""
+    input_dim = layer_config["input_dim"]
+    output_dim = layer_config["output_dim"]
+
+    layer1 = Linear(input_dim, output_dim)
+    layer2 = Linear(input_dim, output_dim)
+
+    # Check if weights and biases are initialized differently
+    assert not np.array_equal(layer1.W, layer2.W), "Weights W should be different"
+    assert np.array_equal(layer1.b, layer2.b), (
+        "Bias b should be equal, as it is initialized to zero"
     )

--- a/tests/layers/test_linear.py
+++ b/tests/layers/test_linear.py
@@ -1,0 +1,128 @@
+import numpy as np
+import pytest
+
+from src.layers.linear import Linear
+
+
+@pytest.fixture
+def layer_config() -> dict[str, int]:
+    return {"input_dim": 10, "output_dim": 5}
+
+
+@pytest.fixture
+def linear_layer(layer_config):
+    return Linear(layer_config["input_dim"], layer_config["output_dim"])
+
+
+@pytest.fixture
+def sample_input_2d(layer_config) -> np.ndarray:
+    batch_size = 4
+    return np.random.randn(batch_size, layer_config["input_dim"])
+
+
+@pytest.fixture
+def sample_input_3d(layer_config) -> np.ndarray:
+    batch_size = 4
+    seq_len = 8
+    return np.random.randn(batch_size, seq_len, layer_config["input_dim"])
+
+
+def test_linear_init(linear_layer, layer_config):
+    """Tests layer initialiaztion: dimensions and default mode."""
+    input_dim = layer_config["input_dim"]
+    output_dim = layer_config["output_dim"]
+
+    assert linear_layer.input_dim == input_dim, (
+        f"Expected input_dim {input_dim}, got {linear_layer.input_dim}"
+    )
+    assert linear_layer.output_dim == output_dim, (
+        f"Expected output_dim {output_dim}, got {linear_layer.output_dim}"
+    )
+
+    # Check weights
+    assert hasattr(linear_layer, "W"), "Weights W not initialized"
+    assert linear_layer.W.shape == (input_dim, output_dim), (
+        f"Expected W shape {(input_dim, output_dim)}, got {linear_layer.W.shape}"
+    )
+    assert np.all(linear_layer.W != 0), "Weights W should not be initialized to zero"
+
+    # Check bias
+    assert hasattr(linear_layer, "b"), "Bias b not initialized"
+    assert linear_layer.b.shape == (output_dim,), (
+        f"Expected b shape {(output_dim,)}, got {linear_layer.b.shape}"
+    )
+    assert np.all(linear_layer.b == 0), "Bias b should be initialized to zero"
+
+
+def test_linear_get_parameters(linear_layer):
+    """Tests get_parameters method."""
+    params = linear_layer.get_parameters()
+
+    assert "W" in params, "Weights W not found in parameters"
+    assert "b" in params, "Bias b not found in parameters"
+
+    assert np.array_equal(params["W"], linear_layer.W), (
+        "Weights W in parameters do not match layer weights"
+    )
+    assert np.array_equal(params["b"], linear_layer.b), (
+        "Bias b in parameters do not match layer bias"
+    )
+
+    assert len(params) == 2, "Expected 2 parameters (W and b)"
+
+
+def test_linear_forward_shape_2d(linear_layer, sample_input_2d):
+    """Tests forward method with 2D input."""
+    output = linear_layer(sample_input_2d)
+    batch_size = sample_input_2d.shape[0]
+    expected_shape = (batch_size, linear_layer.output_dim)
+
+    assert output.shape == expected_shape, (
+        f"Expected output shape {expected_shape}, got {output.shape}"
+    )
+
+
+def test_linear_forward_shape_3d(linear_layer, sample_input_3d):
+    """Tests forward method with 3D input."""
+    output = linear_layer(sample_input_3d)
+    batch_size, seq_len = sample_input_3d.shape[0], sample_input_3d.shape[1]
+    expected_shape = (batch_size, seq_len, linear_layer.output_dim)
+
+    assert output.shape == expected_shape, (
+        f"Expected output shape {expected_shape}, got {output.shape}"
+    )
+
+
+def test_linear_forward_computation(linear_layer, layer_config):
+    """Tests forward pass computation with set weights and input."""
+    input_dim = layer_config["input_dim"]
+    output_dim = layer_config["output_dim"]
+    batch_size = 2
+
+    # input data
+    x = np.array(
+        [[1.0 * i for i in range(input_dim)] for _ in range(batch_size)]
+    )  # Shape (2, 10)
+
+    # set weights and bias
+    W = (
+        np.arange(input_dim * output_dim).reshape((input_dim, output_dim)) * 0.1
+    )  # Shape (10, 5)
+    b = np.arange(output_dim) * 0.1 + 0.1  # Shape (5,)
+
+    linear_layer.set_parameters({"W": W, "b": b})
+
+    # Calculate expected output manually
+    expected_output = x @ W + b
+
+    # Calculate actual output using the layer
+    actual_output = linear_layer(x)
+
+    # Compare results using np.testing.assert_allclose for float precision
+    np.testing.assert_allclose(
+        actual_output,
+        expected_output,
+        rtol=1e-6,
+        atol=1e-6,
+        err_msg="Forward pass computation mismatch",
+    )

--- a/tests/layers/test_linear.py
+++ b/tests/layers/test_linear.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 import pytest
 from numpy import ndarray
@@ -7,27 +9,47 @@ from src.layers.linear import Linear
 
 @pytest.fixture
 def layer_config() -> dict[str, int]:
+    """Basic layer configuration."""
     return {"input_dim": 10, "output_dim": 5}
 
 
-@pytest.fixture
-def linear_layer(layer_config: dict[str, int]) -> Linear:
-    return Linear(layer_config["input_dim"], layer_config["output_dim"])
+@pytest.fixture(params=[True, False], ids=["with_bias", "without_bias"])
+def use_bias(request: pytest.FixtureRequest) -> bool:
+    """Fixture for use_bias parameter."""
+    return request.param
 
 
 @pytest.fixture
-def sample_input_2d(layer_config: dict[str, int]) -> np.ndarray:
+def linear_layer(layer_config: dict[str, int], use_bias: bool) -> Linear:
+    """Parameterized Linear Layer fixture (with and without bias)."""
+    return Linear(
+        input_dim=layer_config["input_dim"],
+        output_dim=layer_config["output_dim"],
+        use_bias=use_bias,
+        seed=42,
+    )
+
+
+@pytest.fixture
+def sample_input_2d(layer_config: dict[str, int]) -> ndarray:
+    """Sample 2D input data."""
     batch_size = 4
-    return np.random.randn(batch_size, layer_config["input_dim"])
+    # Set a fixed seed for reproducibility
+    rng = np.random.default_rng(123)
+    return rng.standard_normal((batch_size, layer_config["input_dim"]))
 
 
 @pytest.fixture
-def sample_input_3d(layer_config: dict[str, int]) -> np.ndarray:
+def sample_input_3d(layer_config: dict[str, int]) -> ndarray:
+    """Sample 3D input data."""
     batch_size = 4
     seq_len = 8
-    return np.random.randn(batch_size, seq_len, layer_config["input_dim"])
+    # Set a fixed seed for reproducibility
+    rng = np.random.default_rng(123)
+    return rng.standard_normal((batch_size, seq_len, layer_config["input_dim"]))
 
 
+# --- Test Functions ---
 def test_linear_init(linear_layer: Linear, layer_config: dict[str, int]) -> None:
     """Tests initialization of linear layer: shape, dimensions ."""
     input_dim = layer_config["input_dim"]
@@ -41,18 +63,55 @@ def test_linear_init(linear_layer: Linear, layer_config: dict[str, int]) -> None
     )
 
     # Check weights
-    assert hasattr(linear_layer, "W"), "Weights W not initialized"
+    assert hasattr(linear_layer, "W"), "Weights W does not exist"
     assert linear_layer.W.shape == (input_dim, output_dim), (
         f"Expected W shape {(input_dim, output_dim)}, got {linear_layer.W.shape}"
     )
     assert np.all(linear_layer.W != 0), "Weights W should not be initialized to zero"
 
     # Check bias
-    assert hasattr(linear_layer, "b"), "Bias b not initialized"
-    assert linear_layer.b.shape == (output_dim,), (
-        f"Expected b shape {(output_dim,)}, got {linear_layer.b.shape}"
-    )
-    assert np.all(linear_layer.b == 0), "Bias b should be initialized to zero"
+    if linear_layer.use_bias:
+        assert hasattr(linear_layer, "b"), "Bias b does not exist"
+        assert linear_layer.b.shape == (output_dim,), (
+            f"Expected b shape {(output_dim,)}, got {linear_layer.b.shape}"
+        )
+        assert np.all(linear_layer.b == 0), "Bias b should be initialized to zero"
+    else:
+        assert hasattr(linear_layer, "b"), (
+            "Attribute b should exist even if use_bias=False (set to None)"
+        )
+        assert linear_layer.b is None, "Bias b should be None when use_bias=False"
+
+
+@pytest.mark.parametrize(
+    "invalid_config, expected_error",
+    [
+        ({"input_dim": 0, "output_dim": 5}, ValueError),
+        ({"input_dim": 10, "output_dim": 0}, ValueError),
+        ({"input_dim": -1, "output_dim": 5}, ValueError),
+        ({"input_dim": 10, "output_dim": -5}, ValueError),
+        ({"input_dim": 10, "output_dim": 5, "seed": "abc"}, ValueError),
+        ({"input_dim": 10, "output_dim": 5, "seed": 1.5}, ValueError),
+    ],
+    ids=[
+        "zero_input_dim",
+        "zero_output_dim",
+        "neg_input_dim",
+        "neg_output_dim",
+        "bad_seed_type_str",
+        "bad_seed_type_float",
+    ],
+)
+def test_linear_init_errors(
+    invalid_config: dict[str, Any], expected_error: type[Exception]
+) -> None:
+    """Tests that Linear layer raises errors on invalid initialization parameters."""
+    input_dim = invalid_config.get("input_dim", 10)
+    output_dim = invalid_config.get("output_dim", 5)
+    seed = invalid_config.get("seed", None)
+
+    with pytest.raises(expected_error):
+        Linear(input_dim=input_dim, output_dim=output_dim, seed=seed)
 
 
 def test_linear_get_parameters(linear_layer: Linear) -> None:
@@ -60,16 +119,44 @@ def test_linear_get_parameters(linear_layer: Linear) -> None:
     params = linear_layer.get_parameters()
 
     assert "W" in params, "Weights W not found in parameters"
-    assert "b" in params, "Bias b not found in parameters"
-
     assert np.array_equal(params["W"], linear_layer.W), (
         "Weights W in parameters do not match layer weights"
     )
-    assert np.array_equal(params["b"], linear_layer.b), (
-        "Bias b in parameters do not match layer bias"
-    )
 
-    assert len(params) == 2, "Expected 2 parameters (W and b)"
+    if linear_layer.use_bias:
+        assert "b" in params, "Bias b not found in parameters"
+        assert np.array_equal(params["b"], linear_layer.b), (
+            "Bias b in parameters do not match layer bias"
+        )
+        assert len(params) == 2, "Expected 2 parameters (W and b)"
+    else:
+        assert "b" not in params, "Bias b should not be present in parameters"
+        assert len(params) == 1, "Expected 1 parameters (W)"
+
+
+def test_linear_set_parameters_valid(linear_layer: Linear) -> None:
+    """Tests setting valid parameters, considering use_bias."""
+    input_dim = linear_layer.input_dim
+    output_dim = linear_layer.output_dim
+
+    # Create new valid parameters
+    new_W = np.random.randn(input_dim, output_dim) * 5
+    params_to_set = {"W": new_W.copy()}
+
+    if linear_layer.use_bias:
+        new_b = np.random.randn(output_dim) * 2
+        params_to_set["b"] = new_b.copy()
+
+    # Set parameters
+    linear_layer.set_parameters(params_to_set)
+
+    # Verify they were set correctly
+    assert np.array_equal(linear_layer.W, new_W)
+    if linear_layer.use_bias:
+        assert linear_layer.b is not None
+        assert np.array_equal(linear_layer.b, new_b)
+    else:
+        assert linear_layer.b is None
 
 
 def test_linear_forward_shape_2d(
@@ -117,10 +204,15 @@ def test_linear_forward_computation(
     )  # Shape (10, 5)
     b = np.arange(output_dim) * 0.1 + 0.1  # Shape (5,)
 
-    linear_layer.set_parameters({"W": W, "b": b})
+    # prepare parameters to set and calculate expected output
+    params_to_set = {"W": W}
+    expected_output = x @ W
+    if linear_layer.use_bias:
+        params_to_set["b"] = b
+        expected_output = expected_output + b
 
-    # Calculate expected output manually
-    expected_output = x @ W + b
+    # Set parameters
+    linear_layer.set_parameters(params_to_set)
 
     # Calculate actual output using the layer
     actual_output = linear_layer(x)
@@ -135,50 +227,59 @@ def test_linear_forward_computation(
     )
 
 
-def test_linears_same_seed(layer_config: dict[str, int]) -> None:
+def test_linears_same_seed(layer_config: dict[str, int], use_bias: bool) -> None:
     """Tests initialization of two linear layers with same seed."""
     input_dim = layer_config["input_dim"]
     output_dim = layer_config["output_dim"]
-
     seed = 42
 
-    layer1 = Linear(input_dim, output_dim, seed=seed)
-    layer2 = Linear(input_dim, output_dim, seed=seed)
+    layer1 = Linear(input_dim, output_dim, use_bias=use_bias, seed=seed)
+    layer2 = Linear(input_dim, output_dim, use_bias=use_bias, seed=seed)
 
     # Check if weights are initialized equally
     assert np.array_equal(layer1.W, layer2.W), "Weights W should be equal"
-    assert np.array_equal(layer1.b, layer2.b), (
-        "Bias b should be equal, as it is initialized to zero"
-    )
+    if use_bias:
+        assert np.array_equal(layer1.b, layer2.b), (
+            "Bias b should be equal, as it is initialized to zero"
+        )
+    else:
+        assert layer1.b is None and layer2.b is None, "Bias should be None for both"
 
 
-def test_linears_diff_seed(layer_config: dict[str, int]) -> None:
+def test_linears_diff_seed(layer_config: dict[str, int], use_bias: bool) -> None:
     """Tests initialization of two linear layers with different seed."""
     input_dim = layer_config["input_dim"]
     output_dim = layer_config["output_dim"]
-
     seed = 42
 
-    layer1 = Linear(input_dim, output_dim, seed=seed)
-    layer2 = Linear(input_dim, output_dim, seed=seed + 1)
+    layer1 = Linear(input_dim, output_dim, use_bias=use_bias, seed=seed)
+    layer2 = Linear(input_dim, output_dim, use_bias=use_bias, seed=seed + 1)
 
     # Check if weights are initialized differently
     assert not np.array_equal(layer1.W, layer2.W), "Weights W should be different"
-    assert np.array_equal(layer1.b, layer2.b), (
-        "Bias b should be equal, as it is initialized to zero"
-    )
+    if use_bias:
+        assert np.array_equal(layer1.b, layer2.b), (
+            "Bias b should be equal, as it is initialized to zero"
+        )
+    else:
+        assert layer1.b is None and layer2.b is None, "Bias should be None for both"
 
 
-def test_linears_no_seed(layer_config: dict[str, int]) -> None:
+def test_linears_no_seed(layer_config: dict[str, int], use_bias: bool) -> None:
     """Tests initialization of two linear layers with no seed (should be different)."""
     input_dim = layer_config["input_dim"]
     output_dim = layer_config["output_dim"]
 
-    layer1 = Linear(input_dim, output_dim)
-    layer2 = Linear(input_dim, output_dim)
+    layer1 = Linear(input_dim, output_dim, use_bias=use_bias)
+    layer2 = Linear(input_dim, output_dim, use_bias=use_bias)
 
     # Check if weights and biases are initialized differently
-    assert not np.array_equal(layer1.W, layer2.W), "Weights W should be different"
-    assert np.array_equal(layer1.b, layer2.b), (
-        "Bias b should be equal, as it is initialized to zero"
+    assert not np.array_equal(layer1.W, layer2.W), (
+        "Weights W should (likely) be different for no seed"
     )
+    if use_bias:
+        assert np.array_equal(layer1.b, layer2.b), (
+            "Bias b should be equal, as it is initialized to zero"
+        )
+    else:
+        assert layer1.b is None and layer2.b is None, "Bias should be None for both"

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,24 @@ revision = 1
 requires-python = ">=3.12"
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -41,12 +59,49 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
 name = "transformer-from-scratch"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "numpy" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "numpy", specifier = ">=2.2.4" }]
+requires-dist = [
+    { name = "numpy", specifier = ">=2.2.4" },
+    { name = "pytest", specifier = ">=8.3.5" },
+]


### PR DESCRIPTION
This pull request adds the basic Linear Layer as well as unit tests.
#### Linear Layer (linear.py)
- Implement Linear Layer, inheriting from BaseLayer, including:
    - `__init__`, taking `input_dim`, `output_dim`, `use_bias` and an optional `seed`
    - `use_bias` flag handles whether bias should be used or not
    - `forward` computes x @ W (+ b)
    - getter and setter for parameters
    - proper shape validations and some error handling
    - initial attempt/concept of `backward` method, currently commented out (might not seem trivial at first, as the code is supposed to take into account more complex shapes such as 3D, e.g. (batch_size, seq_length, input_dim)

#### Testing Linear Layer (test_linear.py)
- Implement testing of Linear Layer, including:
    - setting up fixtures for layer config, using bias, linear layer as well as sample inputs in 2D and 3D
    - test initialization, e.g. dimensions, shapes, error handling
    - test proper handling of bias for get and set methods 
    - test shape of forward pass for both 2D and 3D input
    - test forward computation
    - test seeding (same seed leading to same initialization and so on)