### PR TITLE
Feat/residual

### DIFF
--- a/src/layers/residual.py
+++ b/src/layers/residual.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from numpy import ndarray
 
@@ -8,7 +8,9 @@ from src.layers.normalization import LayerNorm
 
 
 class ResidualConnection(BaseLayer):
-    def __init__(self, normalized_shape: int, dropout_rate: float = 0.0):
+    def __init__(
+        self, normalized_shape: int, eps: Optional[float], dropout_rate: float = 0.0
+    ):
         """
         Initializes ResidualConnection layer.
 
@@ -17,7 +19,7 @@ class ResidualConnection(BaseLayer):
         """
         super().__init__()
         self.dropout = Dropout(dropout_rate)
-        self.layer_norm = LayerNorm(normalized_shape=normalized_shape)
+        self.layer_norm = LayerNorm(normalized_shape=normalized_shape, eps=eps)
 
     def forward(self, x: ndarray, sublayer: Any):
         """

--- a/src/layers/residual.py
+++ b/src/layers/residual.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Optional
 
 from numpy import ndarray
 
@@ -10,7 +10,7 @@ from src.layers.normalization import LayerNorm
 class ResidualConnection(BaseLayer):
     def __init__(
         self, normalized_shape: int, eps: Optional[float], dropout_rate: float = 0.0
-    ):
+    ) -> None:
         """
         Initializes ResidualConnection layer.
 
@@ -21,15 +21,27 @@ class ResidualConnection(BaseLayer):
         self.dropout = Dropout(dropout_rate)
         self.layer_norm = LayerNorm(normalized_shape=normalized_shape, eps=eps)
 
-    def forward(self, x: ndarray, sublayer: Any):
+    def forward(self, x: ndarray, sublayer: BaseLayer) -> ndarray:
         """
         Forward pass through the residual connection layer.
 
         Parameters:
             x (ndarray): Input data.
-            sublayer (Any): The sublayer to apply the residual connection to.
+            sublayer (BaseLayer): The sublayer to apply the residual connection to.
 
         Returns:
             ndarray: Output data after applying the residual connection.
         """
         return x + self.dropout(sublayer(self.layer_norm(x)))
+
+    def train(self) -> None:
+        """Set layer to training mode."""
+        super().train()
+        self.dropout.train()
+        self.layer_norm.train()
+
+    def eval(self) -> None:
+        """Set layer to evaluation mode."""
+        super().eval()
+        self.dropout.eval()
+        self.layer_norm.eval()

--- a/src/layers/residual.py
+++ b/src/layers/residual.py
@@ -9,7 +9,11 @@ from src.layers.normalization import LayerNorm
 
 class ResidualConnection(BaseLayer):
     def __init__(
-        self, normalized_shape: int, eps: Optional[float], dropout_rate: float = 0.0
+        self,
+        normalized_shape: int,
+        eps: Optional[float],
+        dropout_rate: float = 0.0,
+        seed: Optional[int] = None,
     ) -> None:
         """
         Initializes ResidualConnection layer.
@@ -18,7 +22,13 @@ class ResidualConnection(BaseLayer):
             dropout_rate (float): Dropout rate for the layer.
         """
         super().__init__()
-        self.dropout = Dropout(dropout_rate)
+
+        if dropout_rate < 0.0 or dropout_rate > 1.0:
+            raise ValueError("Dropout rate must be between 0 and 1.")
+        if seed is not None and not isinstance(seed, int):
+            raise ValueError("Seed must be an integer.")
+
+        self.dropout = Dropout(dropout_rate, seed=seed)
         self.layer_norm = LayerNorm(normalized_shape=normalized_shape, eps=eps)
 
     def forward(self, x: ndarray, sublayer: BaseLayer) -> ndarray:

--- a/src/layers/residual.py
+++ b/src/layers/residual.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from numpy import ndarray
+
+from src.layers.base import BaseLayer
+from src.layers.dropout import Dropout
+from src.layers.normalization import LayerNorm
+
+
+class ResidualConnection(BaseLayer):
+    def __init__(self, normalized_shape: int, dropout_rate: float = 0.0):
+        """
+        Initializes ResidualConnection layer.
+
+        Parameters:
+            dropout_rate (float): Dropout rate for the layer.
+        """
+        super().__init__()
+        self.dropout = Dropout(dropout_rate)
+        self.layer_norm = LayerNorm(normalized_shape=normalized_shape)
+
+    def forward(self, x: ndarray, sublayer: Any):
+        """
+        Forward pass through the residual connection layer.
+
+        Parameters:
+            x (ndarray): Input data.
+            sublayer (Any): The sublayer to apply the residual connection to.
+
+        Returns:
+            ndarray: Output data after applying the residual connection.
+        """
+        return x + self.dropout(sublayer(self.layer_norm(x)))

--- a/tests/layers/test_residual.py
+++ b/tests/layers/test_residual.py
@@ -169,3 +169,37 @@ def test_residual_forward_with_dropout(
     assert output.shape == x.shape, (
         f"Expected output shape {x.shape}, got {output.shape}"
     )
+
+
+def test_residual_train_eval(
+    residual_layer: ResidualConnection,
+) -> None:
+    """Tests train and eval modes of residual layer."""
+    # should be train mode by default
+    assert residual_layer.training is True, (
+        f"Expected training mode to be True, got {residual_layer.training}"
+    )
+
+    # Set to train mode
+    residual_layer.train()
+    assert residual_layer.training is True, (
+        f"Expected training mode to be True, got {residual_layer.training}"
+    )
+    assert residual_layer.dropout.training is True, (
+        f"Expected training mode to be True, got {residual_layer.dropout.training}"
+    )
+    assert residual_layer.layer_norm.training is True, (
+        f"Expected training mode to be True, got {residual_layer.layer_norm.training}"
+    )
+
+    # Set to eval mode
+    residual_layer.eval()
+    assert residual_layer.training is False, (
+        f"Expected training mode to be False, got {residual_layer.training}"
+    )
+    assert residual_layer.dropout.training is False, (
+        f"Expected training mode to be False, got {residual_layer.dropout.training}"
+    )
+    assert residual_layer.layer_norm.training is False, (
+        f"Expected training mode to be False, got {residual_layer.layer_norm.training}"
+    )

--- a/tests/layers/test_residual.py
+++ b/tests/layers/test_residual.py
@@ -1,0 +1,153 @@
+# from typing import Any
+
+import numpy as np
+import pytest
+
+from src.layers.linear import Linear
+
+# from numpy import ndarray
+from src.layers.residual import ResidualConnection
+
+
+# --- Fixtures ---
+@pytest.fixture
+def layer_config() -> dict[str, int]:
+    """Basic layer configuration."""
+    return {"normalized_shape": 10, "dropout_rate": 0.0, "eps": 0.75}
+
+
+@pytest.fixture
+def linear_layer(layer_config: dict[str, int]) -> Linear:
+    """Linear layer fixture."""
+    return Linear(
+        input_dim=layer_config["normalized_shape"],
+        output_dim=layer_config["normalized_shape"],
+        use_bias=False,
+        seed=42,
+    )
+
+
+@pytest.fixture
+def residual_layer(layer_config: dict[str, int]) -> ResidualConnection:
+    """Residual layer fixture."""
+    return ResidualConnection(
+        normalized_shape=layer_config["normalized_shape"],
+        dropout_rate=layer_config["dropout_rate"],
+        eps=layer_config["eps"],
+    )
+
+
+# --- Test Functions ---
+def test_residual_init(
+    residual_layer: ResidualConnection, layer_config: dict[str, int]
+) -> None:
+    """Tests initialization of residual layer: shape, dimensions."""
+    normalized_shape = layer_config["normalized_shape"]
+    dropout_rate = layer_config["dropout_rate"]
+
+    assert residual_layer.layer_norm.normalized_shape == normalized_shape, (
+        f"Expected normalized_shape {normalized_shape}, got {residual_layer.layer_norm.normalized_shape}"
+    )
+    assert residual_layer.dropout.rate == dropout_rate, (
+        f"Expected dropout_rate {dropout_rate}, got {residual_layer.dropout.dropout_rate}"
+    )
+    assert residual_layer.layer_norm.training is True, (
+        f"Expected training mode to be True, got {residual_layer.layer_norm.training}"
+    )
+
+
+def test_residual_forward(
+    residual_layer: ResidualConnection,
+    linear_layer: Linear,
+    layer_config: dict[str, int],
+) -> None:
+    """Tests forward pass of residual layer."""
+    x = np.random.rand(5, layer_config["normalized_shape"]).astype(
+        np.float32
+    )  # Example input
+    output = residual_layer.forward(x, linear_layer)
+
+    assert output.shape == x.shape, (
+        f"Expected output shape {x.shape}, got {output.shape}"
+    )
+
+
+def test_residual_forward_with_invalid_shape(
+    residual_layer: ResidualConnection,
+    linear_layer: Linear,
+) -> None:
+    """Tests forward pass of residual layer with invalid input shape."""
+    x = np.random.rand(5, 20).astype(np.float32)  # Example input with invalid shape
+
+    with pytest.raises(ValueError):
+        residual_layer.forward(x, linear_layer)
+
+
+def test_residual_forward_with_invalid_sublayer(
+    residual_layer: ResidualConnection,
+    layer_config: dict[str, int],
+) -> None:
+    """Tests forward pass of residual layer with invalid sublayer."""
+    x = np.random.rand(5, layer_config["normalized_shape"]).astype(
+        np.float32
+    )  # Example input
+    invalid_sublayer = x
+
+    with pytest.raises(TypeError):
+        residual_layer.forward(x, invalid_sublayer)
+
+
+def test_residual_forward_deterministic(
+    residual_layer: ResidualConnection,
+    linear_layer: Linear,
+    layer_config: dict[str, int],
+) -> None:
+    """Tests forward pass of residual layer for deterministic output."""
+    x = np.array(
+        [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]]
+    ).astype(np.float32)
+    linear_layer.set_parameters(
+        {
+            "W": np.eye(
+                layer_config["normalized_shape"],
+                dtype=np.float32,
+            )
+        }
+    )
+    output = residual_layer.forward(x, linear_layer)
+    expected_output = np.array(
+        [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]]
+    ).astype(np.float32) + np.array(
+        [
+            [
+                -4.5 / 3,
+                -3.5 / 3,
+                -2.5 / 3,
+                -1.5 / 3,
+                -0.5 / 3,
+                0.5 / 3,
+                1.5 / 3,
+                2.5 / 3,
+                3.5 / 3,
+                4.5 / 3,
+            ],
+            [
+                -4.5 / 3,
+                -3.5 / 3,
+                -2.5 / 3,
+                -1.5 / 3,
+                -0.5 / 3,
+                0.5 / 3,
+                1.5 / 3,
+                2.5 / 3,
+                3.5 / 3,
+                4.5 / 3,
+            ],
+        ]
+    )
+    print(f" output: {output}")
+    print(f"expected_output: {expected_output}")
+
+    assert np.allclose(output, expected_output), (
+        f"Expected output {expected_output}, got {output}"
+    )

--- a/tests/layers/test_residual.py
+++ b/tests/layers/test_residual.py
@@ -70,6 +70,7 @@ def test_residual_forward(
     assert output.shape == x.shape, (
         f"Expected output shape {x.shape}, got {output.shape}"
     )
+    assert isinstance(output, np.ndarray)
 
 
 def test_residual_forward_with_invalid_shape(

--- a/tests/layers/test_residual.py
+++ b/tests/layers/test_residual.py
@@ -151,3 +151,20 @@ def test_residual_forward_deterministic(
     assert np.allclose(output, expected_output), (
         f"Expected output {expected_output}, got {output}"
     )
+
+
+def test_residual_forward_with_dropout(
+    residual_layer: ResidualConnection,
+    linear_layer: Linear,
+    layer_config: dict[str, int],
+) -> None:
+    """Tests forward pass of residual layer with dropout."""
+    x = np.random.rand(5, layer_config["normalized_shape"]).astype(
+        np.float32
+    )  # Example input
+    residual_layer.dropout.rate = 0.5  # Set dropout rate to 50%
+    output = residual_layer.forward(x, linear_layer)
+
+    assert output.shape == x.shape, (
+        f"Expected output shape {x.shape}, got {output.shape}"
+    )


### PR DESCRIPTION
residual.py:
- add residual connection layer class which inherits from abstract BaseLayer
- the residual layer also includes a dropout and normalization layer

test_residual.py:
- add testing for residual layer
- also includes manual written example to verify right calculation

commit history might be a bit messy, i had some issues while pushing remotely because of some false commands
