### PR TITLE
Feat/attention bm

### DIFF
--- a/src/layers/activations/softmax.py
+++ b/src/layers/activations/softmax.py
@@ -8,7 +8,7 @@ class Softmax(BaseLayer):
     Numerically stable Softmax activation.
     """
 
-    def __init__(self, axis: int = -2) -> None:
+    def __init__(self, axis: int = -1) -> None:
         """
         Initialize the Softmax activation function.
 

--- a/src/layers/activations/softmax.py
+++ b/src/layers/activations/softmax.py
@@ -8,7 +8,7 @@ class Softmax(BaseLayer):
     Numerically stable Softmax activation.
     """
 
-    def __init__(self, axis: int = -1) -> None:
+    def __init__(self, axis: int = -2) -> None:
         """
         Initialize the Softmax activation function.
 
@@ -46,6 +46,9 @@ class Softmax(BaseLayer):
         e_x = np.exp(shift_x)
         sum_e_x = np.sum(e_x, axis=self.axis, keepdims=True)
         return e_x / sum_e_x
+
+    def __call__(self, x: np.ndarray, causal_mask: np.ndarray = None) -> np.ndarray:
+        return self.forward(x, causal_mask)
 
     # def backward(self, grad_output: np.ndarray) -> np.ndarray:
     # """

--- a/src/layers/multiheadattentionblock.py
+++ b/src/layers/multiheadattentionblock.py
@@ -1,0 +1,122 @@
+import numpy as np
+from numpy import ndarray
+
+from src.layers.activations.softmax import Softmax
+from src.layers.base import BaseLayer
+from src.layers.dropout import Dropout
+from src.layers.linear import Linear
+
+
+class MultiHeadAttentionBlock(BaseLayer):
+    def __init__(self, d_model: int, n_heads: int, dropout_rate: float) -> None:
+        """Initializes MultiHeadAttentionBlock layer.
+        Parameters:
+            d_model (int): Dimension of the model.
+            n_heads (int): Number of attention heads.
+            dropout_rate (float): Dropout rate.
+        """
+        super().__init__()
+        self.d_model = d_model
+        self.n_heads = n_heads
+        self.dropout_rate = dropout_rate
+
+        # Check for valid input parameters
+        if d_model <= 0 or n_heads <= 0:
+            raise ValueError("d_model and n_heads must be positive integers.")
+        if dropout_rate < 0.0 or dropout_rate > 1.0:
+            raise ValueError("Dropout rate must be between 0 and 1.")
+        if d_model % n_heads != 0:
+            raise ValueError("d_model must be divisible by n_heads.")
+
+        self.head_dim = d_model // n_heads
+
+        # Initialize weights for query, key, value, and output
+        self.w_q = Linear(d_model, d_model, use_bias=False)
+        self.w_k = Linear(d_model, d_model, use_bias=False)
+        self.w_v = Linear(d_model, d_model, use_bias=False)
+        self.w_o = Linear(d_model, d_model, use_bias=False)
+
+        self.dropout = Dropout(dropout_rate)
+        self.softmax = Softmax()
+
+    @staticmethod
+    def attention(
+        query: ndarray,
+        key: ndarray,
+        value: ndarray,
+        mask: ndarray,
+        dropout: Dropout,
+        softmax: Softmax,
+    ) -> ndarray:
+        """Compute attention scores according to the Attention is all you need.
+        Parameters:
+            query (ndarray): Query matrix.
+            key (ndarray): Key matrix.
+            value (ndarray): Value matrix.
+            mask (ndarray): Mask matrix.
+            dropout (Dropout): Dropout layer.
+            softmax (Softmax): Softmax layer.
+        Returns:
+            ndarray: Output matrix after applying attention.
+        """
+        # Check for valid input shapes
+        if query.ndim != 4 or key.ndim != 4 or value.ndim != 4 or mask.ndim != 4:
+            raise ValueError(
+                "Input arrays must be 4-dimensional. Current shapes: "
+                f"query: {query.shape}, key: {key.shape}, value: {value.shape}, mask: {mask.shape}"
+            )
+        d_k = query.shape[-1]
+
+        # Compute attention scores
+        attention_scores = softmax(
+            (query @ key.transpose(0, 2, 1)) / np.sqrt(d_k), mask
+        )
+
+        # Apply dropout to attention scores
+        if dropout is not None:
+            attention_scores = dropout(attention_scores)
+
+        return attention_scores @ value
+
+    def forward(
+        self, query: ndarray, key: ndarray, value: ndarray, mask: ndarray
+    ) -> ndarray:
+        """Forward pass for MultiHeadAttentionBlock.
+        Even though in self attention the query, key and value inputs are the same, we keep them separate
+        to allow for cross attention.
+        This allows for more flexibility in the model architecture.
+        Parameters:
+            query (ndarray): Query input.
+            key (ndarray): Key input.
+            value (ndarray): Value input.
+            mask (ndarray): Mask matrix.
+        Returns:
+            ndarray: Output of the attention block.
+        """
+        query = self.w_q(query)
+        key = self.w_k(key)
+        value = self.w_v(value)
+        # Reshape query, key, value for multi-head attention
+        # (batch_size, seq_len, d_model) -> (batch_size, seq_len, n_heads, head_dim)
+        query = query.reshape(
+            query.shape[0], query.shape[1], self.n_heads, self.head_dim
+        )
+        key = key.reshape(key.shape[0], key.shape[1], self.n_heads, self.head_dim)
+        value = value.reshape(
+            value.shape[0], value.shape[1], self.n_heads, self.head_dim
+        )
+        # Transpose to get the correct shape for multi-head attention
+        # (batch_size, n_heads, seq_len, head_dim)
+        query = query.transpose(0, 2, 1, 3)
+        key = key.transpose(0, 2, 1, 3)
+        value = value.transpose(0, 2, 1, 3)
+
+        x = MultiHeadAttentionBlock.attention(
+            query, key, value, mask, self.dropout, self.softmax
+        )
+
+        # Reshape back to (batch_size, seq_len, d_model)
+        x = x.transpose(0, 2, 1, 3).reshape(
+            query.shape[0], query.shape[1], self.n_heads * self.head_dim
+        )
+        return self.w_o(x)

--- a/src/layers/multiheadattentionblock.py
+++ b/src/layers/multiheadattentionblock.py
@@ -195,3 +195,23 @@ class MultiHeadAttentionBlock(BaseLayer):
         self.w_k.set_parameters({"W": params["w_k"]})
         self.w_v.set_parameters({"W": params["w_v"]})
         self.w_o.set_parameters({"W": params["w_o"]})
+
+    def train(self) -> None:
+        """Set all sublayers to training mode."""
+        super().train()
+        self.dropout.train()
+        self.w_q.train()
+        self.w_k.train()
+        self.w_v.train()
+        self.w_o.train()
+        self.softmax.train()
+
+    def eval(self) -> None:
+        """Set all sublayers to evaluation mode."""
+        super().eval()
+        self.dropout.eval()
+        self.w_q.eval()
+        self.w_k.eval()
+        self.w_v.eval()
+        self.w_o.eval()
+        self.softmax.eval()

--- a/tests/layers/test_multiheadattentionblock.py
+++ b/tests/layers/test_multiheadattentionblock.py
@@ -1,0 +1,170 @@
+import numpy as np
+import pytest
+from numpy import ndarray
+
+from src.layers.multiheadattentionblock import MultiHeadAttentionBlock
+
+# test output shape , done
+# test forward path with known input and output with Dropout disabled , done
+# Single-head vs multi-head equivalence
+# Mask test:
+# Deterministic behavior with fixed seed:
+# invalid parameters or dimensions
+# test get_parameters and set_parameters methods , done
+
+
+@pytest.fixture
+def layer_config() -> dict[str, int]:
+    """Basic layer configuration."""
+    return {"d_model": 10, "n_heads": 2, "dropout_rate": 0.0}
+
+
+@pytest.fixture
+def multihead_attention_block(layer_config: dict[str, int]) -> MultiHeadAttentionBlock:
+    """Parameterized MultiHeadAttentionBlock fixture."""
+    return MultiHeadAttentionBlock(
+        d_model=layer_config["d_model"],
+        n_heads=layer_config["n_heads"],
+        dropout_rate=layer_config["dropout_rate"],
+    )
+
+
+@pytest.fixture
+def input_parameters() -> dict[str, int]:
+    """Parameters for the input data"""
+    return {"batch_size": 3, "seq_len": 8}
+
+
+@pytest.fixture
+def sample_input_3d(
+    layer_config: dict[str, int], input_parameters: dict[str, int]
+) -> ndarray:
+    """Sample 3D input data."""
+    # Set a fixed seed for reproducibility
+    rng = np.random.default_rng(42)
+    return rng.standard_normal(
+        (
+            input_parameters["batch_size"],
+            input_parameters["seq_len"],
+            layer_config["d_model"],
+        )
+    )
+
+
+@pytest.fixture
+def sample_causal_mask(
+    layer_config: dict[str, int], input_parameters: dict[str, int]
+) -> ndarray:
+    """Sample causal mask."""
+    # Set a fixed seed for reproducibility
+    rng = np.random.default_rng(42)
+    mask = np.tril(
+        np.ones(
+            (input_parameters["seq_len"], input_parameters["seq_len"]), dtype=np.float32
+        )
+    )
+    mask = (
+        rng.standard_normal(
+            (
+                input_parameters["batch_size"],
+                layer_config["n_heads"],
+                input_parameters["seq_len"],
+                input_parameters["seq_len"],
+            )
+        )
+        * mask
+    )
+    return mask
+
+
+def test_output_shape(
+    multihead_attention_block: MultiHeadAttentionBlock,
+    sample_input_3d: ndarray,
+    sample_causal_mask: ndarray,
+) -> None:
+    """
+    Test that the output shape is correct.
+    """
+    output = multihead_attention_block(
+        sample_input_3d, sample_input_3d, sample_input_3d, sample_causal_mask
+    )
+    assert isinstance(output, np.ndarray), "Output is not a numpy array."
+    assert output.shape == sample_input_3d.shape, (
+        "Output shape does not match input shape."
+    )
+
+
+def test_get_parameters(
+    multihead_attention_block: MultiHeadAttentionBlock,
+) -> None:
+    """
+    Test get_parameters method.
+    """
+    parameters = multihead_attention_block.get_parameters()
+    assert isinstance(parameters, dict), "Parameters should be a dictionary."
+    assert len(parameters) == 4, "Expected 4 parameters."
+    assert "w_q" in parameters, "w_q parameter not found."
+    assert "w_k" in parameters, "w_k parameter not found."
+    assert "w_v" in parameters, "w_v parameter not found."
+    assert "w_o" in parameters, "w_o parameter not found."
+
+
+def test_set_parameters(
+    multihead_attention_block: MultiHeadAttentionBlock,
+) -> None:
+    """
+    Test set_parameters method.
+    """
+    d_model = multihead_attention_block.d_model
+
+    # Create new valid parameters
+    new_w_q = np.random.randn(d_model, d_model) * 5
+    new_w_k = np.random.randn(d_model, d_model) * 5
+    new_w_v = np.random.randn(d_model, d_model) * 5
+    new_w_o = np.random.randn(d_model, d_model) * 5
+    params_to_set = {
+        "w_q": new_w_q.copy(),
+        "w_k": new_w_k.copy(),
+        "w_v": new_w_v.copy(),
+        "w_o": new_w_o.copy(),
+    }
+
+    multihead_attention_block.set_parameters(params_to_set)
+
+    assert np.array_equal(multihead_attention_block.w_q.W, new_w_q)
+    assert np.array_equal(multihead_attention_block.w_k.W, new_w_k)
+    assert np.array_equal(multihead_attention_block.w_v.W, new_w_v)
+    assert np.array_equal(multihead_attention_block.w_o.W, new_w_o)
+
+
+def test_forward_path() -> None:
+    """
+    Test the forward path.
+    """
+    mhab = MultiHeadAttentionBlock(d_model=4, n_heads=1, dropout_rate=0.0)
+    x = np.array([[[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]])
+    mask = np.array([[[[1, 0, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0], [1, 1, 1, 1]]]])
+    d_model = mhab.d_model
+    weights = np.ones((d_model, d_model), dtype=np.float32)
+    params_to_set = {
+        "w_q": weights.copy(),
+        "w_k": weights.copy(),
+        "w_v": weights.copy(),
+        "w_o": weights.copy(),
+    }
+    mhab.set_parameters(params_to_set)
+    output = mhab(x, x, x, mask)
+    print(output)
+    expected_output = np.array(
+        [
+            [
+                [40, 40, 40, 40],
+                [40, 40, 40, 40],
+                [40, 40, 40, 40],
+                [40, 40, 40, 40],
+            ]
+        ]
+    )
+    assert np.array_equal(output, expected_output), (
+        "Output does not match expected output."
+    )


### PR DESCRIPTION
multiheadattentionblock.py:
- add mha layer and basic functionality from the attention mechanism provided by attention is all you need paper
- create the query, key, value and output weight matrices
- calculate the attention scores, dependent on input and masking
- include get and set parameter functions

testing_multiheadattentionblock.py
- test various wrong initializations 
- test get and set parameters
- test the forward path with a hand calculated expected output