### PR TITLE
Feat/feedforward

### DIFF
--- a/src/layers/feedforward.py
+++ b/src/layers/feedforward.py
@@ -11,7 +11,10 @@ from src.layers.linear import Linear
 
 class FeedForwardBlock(BaseLayer):
     """
-    Feedforward block applying x -> Linear -> ReLU -> Dropout -> Linear.
+    Implements Feed Forward Block typically found in Transformer architectures.
+
+    Consists of two linear layers with a ReLU activation and dropout in between.
+    x -> Linear1 -> ReLU -> Dropout -> Linear2
     """
 
     def __init__(
@@ -31,9 +34,18 @@ class FeedForwardBlock(BaseLayer):
         if d_model <= 0 or d_ff <= 0:
             raise ValueError("d_model and d_ff must be positive integers.")
 
+        if not isinstance(dropout, (int, float)) or not (0.0 <= dropout < 1.0):
+            raise ValueError("Dropout must be a float in [0.0, 1.0).")
+
         if seed is not None and not isinstance(seed, int):
             raise ValueError("Seed must be an integer.")
 
+        # store configuration
+        self.d_model = d_model
+        self.d_ff = d_ff
+        self.dropout_rate = dropout
+
+        # generate random seeds for layers if seed is provided
         if seed is not None:
             main_rng = np.random.default_rng(seed)
             max_seed_val = 2**31 - 1
@@ -46,33 +58,35 @@ class FeedForwardBlock(BaseLayer):
             dropout_seed = None
             linear2_seed = None
 
+        # Initialize layers
         self.linear1 = Linear(d_model, d_ff, use_bias=True, seed=linear1_seed)
         self.relu = ReLU()
-        self.dropout = Dropout(dropout, seed=dropout_seed)
+        self.dropout_layer = Dropout(dropout, seed=dropout_seed)
         self.linear2 = Linear(d_ff, d_model, use_bias=True, seed=linear2_seed)
 
-        self._layers = [
-            self.linear1,
-            self.relu,
-            self.dropout,
-            self.linear2,
-        ]
+        # dictionary of layers with meaningful names for parameter handling & forward pass
+        self._layers = {
+            "linear1": self.linear1,
+            "relu": self.relu,
+            "dropout": self.dropout_layer,
+            "linear2": self.linear2,
+        }
 
         def train(self) -> None:
             """Set the layer to training mode."""
-            self.training = True
+            super().train()
             for layer in self._layers:
                 layer.train()
 
         def eval(self) -> None:
             """Set the layer to evaluation mode."""
-            self.training = False
+            super().eval()
             for layer in self._layers:
                 layer.eval()
 
         def forward(self, x: ndarray, **kwargs: Any) -> ndarray:
             """
-            Forward pass through the feedforward block.
+            Forward pass through the feedforward block by iterating through layers dictionary in order.
 
             Parameters:
                 x (ndarray): Input tensor of shape (batch_size, seq_len, d_model).
@@ -80,6 +94,6 @@ class FeedForwardBlock(BaseLayer):
             Returns:
                 ndarray: Output tensor of shape (batch_size, seq_len, d_model).
             """
-            for layer in self._layers:
+            for layer in self._layers.values():
                 x = layer.forward(x)
             return x

--- a/src/layers/feedforward.py
+++ b/src/layers/feedforward.py
@@ -115,13 +115,11 @@ class FeedForwardBlock(BaseLayer):
         processed_keys = set()
 
         for prefixed_key, param_value in params.items():
-            found_layer = False
             for layer_name in params_by_layer.keys():
                 prefix = f"{layer_name}_"
                 if prefixed_key.startswith(prefix):
                     original_param_name = prefixed_key[len(prefix) :]
                     params_by_layer[layer_name][original_param_name] = param_value
-                    found_layer = True
                     processed_keys.add(prefixed_key)
                     break
 
@@ -142,7 +140,7 @@ class FeedForwardBlock(BaseLayer):
                         f"Unexpected error setting parameters for sub-layer '{layer_name}': {e}"
                     ) from e
 
-    # def backward(self, output_grad: ndarray) -> ndarray:
+    # def backward(self, grad_output: ndarray) -> ndarray:
     #     """
     #     Performs backward pass through the feedforward block.
 
@@ -151,11 +149,11 @@ class FeedForwardBlock(BaseLayer):
     #     their definition in self._sub_layers.
 
     #     Parameters:
-    #         output_grad (ndarray): Gradient of the loss with respect to the output of this block.
+    #         grad_output (ndarray): Gradient of the loss with respect to the output of this block.
 
     #     Returns:
     #         ndarray: Gradient of the loss with respect to the input of this block.
     #     """
     #     for layer in reversed(self._layers.values()):
-    #         output_grad = layer.backward(output_grad)
-    #     return output_grad
+    #         grad_output = layer.backward(grad_output)
+    #     return grad_output

--- a/src/layers/feedforward.py
+++ b/src/layers/feedforward.py
@@ -1,0 +1,85 @@
+from typing import Any, Optional
+
+import numpy as np
+from numpy import ndarray
+
+from src.layers.activations.relu import ReLU
+from src.layers.base import BaseLayer
+from src.layers.dropout import Dropout
+from src.layers.linear import Linear
+
+
+class FeedForwardBlock(BaseLayer):
+    """
+    Feedforward block applying x -> Linear -> ReLU -> Dropout -> Linear.
+    """
+
+    def __init__(
+        self, d_model: int, d_ff: int, dropout: float, seed: Optional[int] = None
+    ) -> None:
+        """
+        Initializes the FeedForwardBlock.
+
+        Parameters:
+            d_model (int): Dimension of the input and output.
+            d_ff (int): Dimension of the feedforward layer.
+            dropout (float): Dropout rate.
+            seed (Optional[int]): Seed for random number generator.
+        """
+        super().__init__()
+
+        if d_model <= 0 or d_ff <= 0:
+            raise ValueError("d_model and d_ff must be positive integers.")
+
+        if seed is not None and not isinstance(seed, int):
+            raise ValueError("Seed must be an integer.")
+
+        if seed is not None:
+            main_rng = np.random.default_rng(seed)
+            max_seed_val = 2**31 - 1
+            seeds = main_rng.integers(0, max_seed_val, size=3)
+            linear1_seed = int(seeds[0])
+            dropout_seed = int(seeds[1])
+            linear2_seed = int(seeds[2])
+        else:
+            linear1_seed = None
+            dropout_seed = None
+            linear2_seed = None
+
+        self.linear1 = Linear(d_model, d_ff, use_bias=True, seed=linear1_seed)
+        self.relu = ReLU()
+        self.dropout = Dropout(dropout, seed=dropout_seed)
+        self.linear2 = Linear(d_ff, d_model, use_bias=True, seed=linear2_seed)
+
+        self._layers = [
+            self.linear1,
+            self.relu,
+            self.dropout,
+            self.linear2,
+        ]
+
+        def train(self) -> None:
+            """Set the layer to training mode."""
+            self.training = True
+            for layer in self._layers:
+                layer.train()
+
+        def eval(self) -> None:
+            """Set the layer to evaluation mode."""
+            self.training = False
+            for layer in self._layers:
+                layer.eval()
+
+        def forward(self, x: ndarray, **kwargs: Any) -> ndarray:
+            """
+            Forward pass through the feedforward block.
+
+            Parameters:
+                x (ndarray): Input tensor of shape (batch_size, seq_len, d_model).
+
+            Returns:
+                ndarray: Output tensor of shape (batch_size, seq_len, d_model).
+            """
+            for layer in self._layers:
+                x = layer.forward(x)
+            return x

--- a/src/layers/feedforward.py
+++ b/src/layers/feedforward.py
@@ -109,15 +109,21 @@ class FeedForwardBlock(BaseLayer):
 
     def set_parameters(self, params: Dict[str, ndarray]) -> None:
         """Sets parameters, expecting prefixed keys."""
+        # set up dictionary with layer names as keys and empty dicts for parameters
         params_by_layer = {
             name: {} for name, layer in self._layers.items() if layer.get_parameters()
         }
         processed_keys = set()
 
+        # check if existing layer_names are in params dictionary
+        # iterate over passed params
         for prefixed_key, param_value in params.items():
+            # iterate over existing layer names
             for layer_name in params_by_layer.keys():
                 prefix = f"{layer_name}_"
+                # check if prefixed_key starts with the layer name
                 if prefixed_key.startswith(prefix):
+                    # extract original parameter name (e.g. "linear1_W" -> "W")
                     original_param_name = prefixed_key[len(prefix) :]
                     params_by_layer[layer_name][original_param_name] = param_value
                     processed_keys.add(prefixed_key)
@@ -127,6 +133,7 @@ class FeedForwardBlock(BaseLayer):
             missing_keys = set(params.keys()) - processed_keys
             raise ValueError(f"Missing parameters for layers: {missing_keys}")
 
+        # set parameters for each layer by using created and validated dictionary
         for layer_name, layer_params_dict in params_by_layer.items():
             if layer_params_dict:
                 try:

--- a/src/layers/feedforward.py
+++ b/src/layers/feedforward.py
@@ -64,7 +64,7 @@ class FeedForwardBlock(BaseLayer):
         self.dropout_layer = Dropout(dropout, seed=dropout_seed)
         self.linear2 = Linear(d_ff, d_model, use_bias=True, seed=linear2_seed)
 
-        # dictionary of layers with meaningful names for parameter handling & forward pass
+        # dictionary of layers with meaningful names for parameter handling & correct order for forward/backward pass
         self._layers = {
             "linear1": self.linear1,
             "relu": self.relu,
@@ -72,28 +72,28 @@ class FeedForwardBlock(BaseLayer):
             "linear2": self.linear2,
         }
 
-        def train(self) -> None:
-            """Set the layer to training mode."""
-            super().train()
-            for layer in self._layers:
-                layer.train()
+    def train(self) -> None:
+        """Set the layer to training mode."""
+        super().train()
+        for layer in self._layers:
+            layer.train()
 
-        def eval(self) -> None:
-            """Set the layer to evaluation mode."""
-            super().eval()
-            for layer in self._layers:
-                layer.eval()
+    def eval(self) -> None:
+        """Set the layer to evaluation mode."""
+        super().eval()
+        for layer in self._layers:
+            layer.eval()
 
-        def forward(self, x: ndarray, **kwargs: Any) -> ndarray:
-            """
-            Forward pass through the feedforward block by iterating through layers dictionary in order.
+    def forward(self, x: ndarray, **kwargs: Any) -> ndarray:
+        """
+        Forward pass through the feedforward block by iterating through layers dictionary in order.
 
-            Parameters:
-                x (ndarray): Input tensor of shape (batch_size, seq_len, d_model).
+        Parameters:
+            x (ndarray): Input tensor of shape (batch_size, seq_len, d_model).
 
-            Returns:
-                ndarray: Output tensor of shape (batch_size, seq_len, d_model).
-            """
-            for layer in self._layers.values():
-                x = layer.forward(x)
-            return x
+        Returns:
+            ndarray: Output tensor of shape (batch_size, seq_len, d_model).
+        """
+        for layer in self._layers.values():
+            x = layer.forward(x)
+        return x

--- a/src/layers/linear.py
+++ b/src/layers/linear.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional
 
 import numpy as np
+from numpy import ndarray
 
 from src.layers.base import BaseLayer
 
@@ -56,7 +57,7 @@ class Linear(BaseLayer):
         # self.dW = None
         # self.db = None
 
-    def forward(self, x: np.ndarray, **kwargs: Any) -> np.ndarray:
+    def forward(self, x: ndarray, **kwargs: Any) -> ndarray:
         """
         Forward pass through the layer.
 
@@ -82,12 +83,12 @@ class Linear(BaseLayer):
             output = output + self.b
         return output
 
-    def get_parameters(self) -> Dict[str, np.ndarray]:
+    def get_parameters(self) -> Dict[str, ndarray]:
         """
         Get the parameters of the layer.
 
         Returns:
-            Dict[str, np.ndarray]: Dictionary of parameters.
+            Dict[str, ndarray]: Dictionary of parameters.
         """
         params = {"W": self.W}
         if self.use_bias:
@@ -95,12 +96,12 @@ class Linear(BaseLayer):
             params["b"] = self.b
         return params
 
-    def set_parameters(self, params: Dict[str, np.ndarray]) -> None:
+    def set_parameters(self, params: Dict[str, ndarray]) -> None:
         """
         Set the parameters of the layer.
 
         Parameters:
-            params (Dict[str, np.ndarray]): Dictionary of parameters.
+            params (Dict[str, ndarray]): Dictionary of parameters.
         """
         # Set weights
         if "W" in params:
@@ -136,15 +137,15 @@ class Linear(BaseLayer):
                 )
             self.b = None
 
-    # def backward(self, grad_output: np.ndarray) -> np.ndarray:
+    # def backward(self, grad_output: ndarray) -> ndarray:
     #     """
     #     Computes gradients w.r.t. inputs and parameters.
 
     #     Parameters:
-    #         grad_output (np.ndarray): Gradient of the loss w.r.t. the output of this layer.
+    #         grad_output (ndarray): Gradient of the loss w.r.t. the output of this layer.
 
     #     Returns:
-    #         np.ndarray: Gradient of the loss w.r.t. the input of this layer.
+    #         ndarray: Gradient of the loss w.r.t. the input of this layer.
     #     """
     #     if self._input_cache is None:
     #         raise ValueError("No input cache found. Forward pass must be called first.")

--- a/tests/layers/test_feedforward.py
+++ b/tests/layers/test_feedforward.py
@@ -123,7 +123,7 @@ def test_ff_init_invalid_params(invalid_params: dict, error_msg_match: str) -> N
         FeedForwardBlock(**invalid_params)
 
 
-def test_ff_train_eval_propagation(ff_block: FeedForwardBlock):
+def test_ff_train_eval_propagation(ff_block: FeedForwardBlock) -> None:
     """Tests if train/eval mode propagates correctly to sub-layers."""
     # Initial state (should be training)
     assert ff_block.training is True
@@ -180,7 +180,7 @@ def test_ff_forward_shape(
     )
 
 
-def test_ff_get_parameters(ff_block_seeded: FeedForwardBlock):
+def test_ff_get_parameters(ff_block_seeded: FeedForwardBlock) -> None:
     """Tests the get_parameters method."""
     params = ff_block_seeded.get_parameters()
 
@@ -201,7 +201,7 @@ def test_ff_get_parameters(ff_block_seeded: FeedForwardBlock):
     assert params["linear2_b"].shape == (ff_block_seeded.d_model,)
 
 
-def test_ff_set_parameters_valid(ff_block: FeedForwardBlock):
+def test_ff_set_parameters_valid(ff_block: FeedForwardBlock) -> None:
     """Tests setting valid parameters using set_parameters."""
     d_model = ff_block.d_model
     d_ff = ff_block.d_ff
@@ -298,7 +298,7 @@ def test_ff_seed_derivation_reproducibility(ff_config: dict, ff_seed: int) -> No
     assert_array_equal(params1["linear2_W"], params2["linear2_W"])
     assert_array_equal(params1["linear2_b"], params2["linear2_b"])
 
-    # Check linear layers are different
+    # Check linear layers are different (within the same block)
     assert not np.array_equal(params1["linear1_W"], params1["linear2_W"]), (
         "Weights of linear1 and linear2 should differ even with the same main seed."
     )

--- a/tests/layers/test_feedforward.py
+++ b/tests/layers/test_feedforward.py
@@ -1,0 +1,344 @@
+import re
+from typing import Dict
+
+import numpy as np
+import pytest
+from numpy import ndarray
+from numpy.testing import assert_allclose, assert_array_equal
+
+from src.layers.feedforward import FeedForwardBlock
+
+
+@pytest.fixture
+def ff_config() -> Dict:
+    """Basic FeedForwardBlock configuration."""
+    return {"d_model": 16, "d_ff": 32, "dropout": 0.1}
+
+
+@pytest.fixture
+def ff_seed() -> int:
+    """Seed for reproducible tests."""
+    return 42
+
+
+@pytest.fixture
+def ff_block(ff_config: dict) -> FeedForwardBlock:
+    """Fixture for FeedForwardBlock."""
+    return FeedForwardBlock(
+        d_model=ff_config["d_model"],
+        d_ff=ff_config["d_ff"],
+        dropout=ff_config["dropout"],
+        seed=None,
+    )
+
+
+@pytest.fixture
+def ff_block_seeded(ff_config: dict, ff_seed: int) -> FeedForwardBlock:
+    """Fixture for FeedForwardBlock with a seed."""
+    return FeedForwardBlock(
+        d_model=ff_config["d_model"],
+        d_ff=ff_config["d_ff"],
+        dropout=ff_config["dropout"],
+        seed=ff_seed,
+    )
+
+
+@pytest.fixture
+def sample_input_ff_2d(ff_config: dict) -> ndarray:
+    """Sample 2D input data (batch, d_model)."""
+    batch_size = 4
+    rng = np.random.default_rng(123)
+    return rng.standard_normal((batch_size, ff_config["d_model"])).astype(np.float32)
+
+
+@pytest.fixture
+def sample_input_ff_3d(ff_config: dict) -> ndarray:
+    """Sample 3D input data (batch, seq_len, d_model)."""
+    batch_size = 4
+    seq_len = 8
+    rng = np.random.default_rng(123)
+    return rng.standard_normal((batch_size, seq_len, ff_config["d_model"])).astype(
+        np.float32
+    )
+
+
+# --- Test Functions ---+
+
+
+@pytest.mark.parametrize(
+    "invalid_params, error_msg_match",
+    [
+        (
+            {"d_model": 0, "d_ff": 32, "dropout": 0.1},
+            "d_model and d_ff must be positive",
+        ),
+        (
+            {"d_model": 16, "d_ff": 0, "dropout": 0.1},
+            "d_model and d_ff must be positive",
+        ),
+        (
+            {"d_model": 16, "d_ff": -5, "dropout": 0.1},
+            "d_model and d_ff must be positive",
+        ),
+        (
+            {"d_model": 16, "d_ff": 32, "dropout": -0.1},
+            re.escape("Dropout must be a float in [0.0, 1.0)"),
+        ),
+        (
+            {"d_model": 16, "d_ff": 32, "dropout": 1.0},
+            re.escape("Dropout must be a float in [0.0, 1.0)"),
+        ),
+        (
+            {"d_model": 16, "d_ff": 32, "dropout": 1.1},
+            re.escape("Dropout must be a float in [0.0, 1.0)"),
+        ),
+        (
+            {"d_model": 16, "d_ff": 32, "dropout": "abc"},
+            re.escape("Dropout must be a float in [0.0, 1.0)"),
+        ),
+        (
+            {"d_model": 16, "d_ff": 32, "dropout": 0.1, "seed": "xyz"},
+            "Seed must be an integer",
+        ),
+        (
+            {"d_model": 16, "d_ff": 32, "dropout": 0.1, "seed": 1.5},
+            "Seed must be an integer",
+        ),
+    ],
+    ids=[
+        "zero_d_model",
+        "zero_d_ff",
+        "neg_d_ff",
+        "neg_dropout",
+        "dropout_eq_1",
+        "dropout_gt_1",
+        "dropout_str",
+        "seed_str",
+        "seed_float",
+    ],
+)
+def test_ff_init_invalid_params(invalid_params: dict, error_msg_match: str) -> None:
+    """Tests that FeedForwardBlock raises ValueError for invalid initialization parameters."""
+    with pytest.raises(ValueError, match=error_msg_match):
+        FeedForwardBlock(**invalid_params)
+
+
+def test_ff_train_eval_propagation(ff_block: FeedForwardBlock):
+    """Tests if train/eval mode propagates correctly to sub-layers."""
+    # Initial state (should be training)
+    assert ff_block.training is True
+    assert ff_block.linear1.training is True
+    assert ff_block.relu.training is True
+    assert ff_block.dropout_layer.training is True
+    assert ff_block.linear2.training is True
+
+    # Switch to eval mode
+    ff_block.eval()
+    assert ff_block.training is False
+    assert ff_block.linear1.training is False
+    assert ff_block.relu.training is False
+    assert ff_block.dropout_layer.training is False
+    assert ff_block.linear2.training is False
+
+    # Switch back to train mode
+    ff_block.train()
+    assert ff_block.training is True
+    assert ff_block.linear1.training is True
+    assert ff_block.relu.training is True
+    assert ff_block.dropout_layer.training is True
+    assert ff_block.linear2.training is True
+
+
+@pytest.mark.parametrize(
+    "input_fixture",
+    ["sample_input_ff_2d", "sample_input_ff_3d"],
+    ids=["2D_Input", "3D_Input"],
+)
+def test_ff_forward_shape(
+    ff_block_seeded: FeedForwardBlock,
+    input_fixture: str,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Tests the output shape of the forward pass for 2D and 3D inputs."""
+    sample_input = request.getfixturevalue(input_fixture)
+    d_model = ff_block_seeded.d_model
+    expected_shape = list(sample_input.shape)
+    expected_shape[-1] = d_model  # Output dimension should match d_model
+
+    # Test in training mode
+    ff_block_seeded.train()
+    output_train = ff_block_seeded(sample_input.copy())
+    assert output_train.shape == tuple(expected_shape), (
+        f"Train mode output shape mismatch. Expected {tuple(expected_shape)}, got {output_train.shape}"
+    )
+
+    # Test in eval mode
+    ff_block_seeded.eval()
+    output_eval = ff_block_seeded(sample_input.copy())
+    assert output_eval.shape == tuple(expected_shape), (
+        f"Eval mode output shape mismatch. Expected {tuple(expected_shape)}, got {output_eval.shape}"
+    )
+
+
+def test_ff_get_parameters(ff_block_seeded: FeedForwardBlock):
+    """Tests the get_parameters method."""
+    params = ff_block_seeded.get_parameters()
+
+    expected_keys = {"linear1_W", "linear1_b", "linear2_W", "linear2_b"}
+    assert set(params.keys()) == expected_keys, "Parameter keys mismatch."
+
+    # Check shapes and values against actual layer parameters
+    assert_array_equal(params["linear1_W"], ff_block_seeded.linear1.W)
+    assert params["linear1_W"].shape == (ff_block_seeded.d_model, ff_block_seeded.d_ff)
+
+    assert_array_equal(params["linear1_b"], ff_block_seeded.linear1.b)
+    assert params["linear1_b"].shape == (ff_block_seeded.d_ff,)
+
+    assert_array_equal(params["linear2_W"], ff_block_seeded.linear2.W)
+    assert params["linear2_W"].shape == (ff_block_seeded.d_ff, ff_block_seeded.d_model)
+
+    assert_array_equal(params["linear2_b"], ff_block_seeded.linear2.b)
+    assert params["linear2_b"].shape == (ff_block_seeded.d_model,)
+
+
+def test_ff_set_parameters_valid(ff_block: FeedForwardBlock):
+    """Tests setting valid parameters using set_parameters."""
+    d_model = ff_block.d_model
+    d_ff = ff_block.d_ff
+
+    # Create new parameters with different values
+    new_params = {
+        "linear1_W": np.random.randn(d_model, d_ff).astype(np.float32),
+        "linear1_b": np.random.randn(d_ff).astype(np.float32),
+        "linear2_W": np.random.randn(d_ff, d_model).astype(np.float32),
+        "linear2_b": np.random.randn(d_model).astype(np.float32),
+    }
+
+    # Set the new parameters
+    ff_block.set_parameters(new_params)
+
+    # Verify the parameters were updated in the layers
+    assert_array_equal(ff_block.linear1.W, new_params["linear1_W"])
+    assert_array_equal(ff_block.linear1.b, new_params["linear1_b"])
+    assert_array_equal(ff_block.linear2.W, new_params["linear2_W"])
+    assert_array_equal(ff_block.linear2.b, new_params["linear2_b"])
+
+    # Verify get_parameters reflects the changes
+    retrieved_params = ff_block.get_parameters()
+    assert len(retrieved_params) == 4
+    assert_array_equal(retrieved_params["linear1_W"], new_params["linear1_W"])
+    assert_array_equal(retrieved_params["linear2_b"], new_params["linear2_b"])
+
+
+@pytest.mark.parametrize(
+    "invalid_params, error_type, error_match",
+    [
+        # Wrong shape
+        (
+            {"linear1_W": np.zeros((1, 1))},
+            ValueError,
+            "Error setting parameters for sub-layer 'linear1'",
+        ),
+        # Missing linear2_b
+        (
+            {
+                "linear1_W": np.zeros((16, 32)),
+                "linear1_b": np.zeros((32)),
+                "linear2_W": np.zeros((32, 16)),
+            },
+            ValueError,
+            "Error setting parameters for sub-layer 'linear2'",
+        ),
+        # Extra key check
+        (
+            {
+                "linear1_W": np.zeros((16, 32)),
+                "linear1_b": np.zeros((32)),
+                "linear2_W": np.zeros((32, 16)),
+                "linear2_b": np.zeros((16)),
+                "extra_param": np.zeros(1),
+            },
+            ValueError,
+            "Missing parameters for layers: {'extra_param'}",
+        ),
+        # Wrong prefix
+        (
+            {"wrongprefix_W": np.zeros((16, 32))},
+            ValueError,
+            "Missing parameters for layers: {'wrongprefix_W'}",
+        ),
+    ],
+    ids=["wrong_shape_l1w", "missing_l2b", "extra_key", "wrong_prefix"],
+)
+def test_ff_set_parameters_invalid(
+    ff_block_seeded: FeedForwardBlock,
+    invalid_params: dict,
+    error_type: type[Exception],
+    error_match: str,
+) -> None:
+    """Tests that set_parameters raises errors for invalid inputs."""
+
+    with pytest.raises(error_type, match=error_match):
+        ff_block_seeded.set_parameters(invalid_params)
+
+
+def test_ff_seed_derivation_reproducibility(ff_config: dict, ff_seed: int) -> None:
+    """Tests that the same seed produces identical blocks, and derived seeds differ."""
+    # Create two blocks with the same seed
+    block1 = FeedForwardBlock(seed=ff_seed, **ff_config)
+    block2 = FeedForwardBlock(seed=ff_seed, **ff_config)
+
+    # Get parameters
+    params1 = block1.get_parameters()
+    params2 = block2.get_parameters()
+
+    # Check parameters are identical between blocks with same seed
+    assert_array_equal(params1["linear1_W"], params2["linear1_W"])
+    assert_array_equal(params1["linear1_b"], params2["linear1_b"])
+    assert_array_equal(params1["linear2_W"], params2["linear2_W"])
+    assert_array_equal(params1["linear2_b"], params2["linear2_b"])
+
+    # Check linear layers are different
+    assert not np.array_equal(params1["linear1_W"], params1["linear2_W"]), (
+        "Weights of linear1 and linear2 should differ even with the same main seed."
+    )
+
+    # Verify dropout reproducibility (by checking forward pass)
+    block1.train()
+    block2.train()
+    input_data = np.random.randn(2, ff_config["d_model"]).astype(np.float32)
+    output1 = block1(input_data.copy())
+    mask1 = block1.dropout_layer._mask.copy()
+    output2 = block2(input_data.copy())
+    mask2 = block2.dropout_layer._mask.copy()
+
+    assert_array_equal(
+        mask1, mask2, "Dropout masks should be identical for the same seed."
+    )
+    assert_allclose(
+        output1, output2, err_msg="Outputs should be identical for the same seed."
+    )
+
+
+def test_ff_different_seeds(ff_config: dict, ff_seed: int) -> None:
+    """Tests that different seeds produce different blocks."""
+    block1 = FeedForwardBlock(seed=ff_seed, **ff_config)
+    block2 = FeedForwardBlock(seed=ff_seed + 1, **ff_config)
+
+    params1 = block1.get_parameters()
+    params2 = block2.get_parameters()
+
+    # Check parameters are different between blocks
+    assert not np.array_equal(params1["linear1_W"], params2["linear1_W"])
+    assert not np.array_equal(params1["linear2_W"], params2["linear2_W"])
+
+    # Verify dropout difference (by checking forward pass)
+    block1.train()
+    block2.train()
+    input_data = np.random.randn(2, ff_config["d_model"]).astype(np.float32)
+    output1 = block1(input_data.copy())
+    output2 = block2(input_data.copy())
+
+    assert not np.allclose(output1, output2), (
+        "Outputs should differ for different seeds."
+    )


### PR DESCRIPTION
This pull request implements FeedForward-Block.
#### FeedForward-Block:
- `__init__` takes `d_model`, `d_ff`, `dropout`, and an optional `seed` to configure the FeedForward-Block
- `train` and `eval` methods to properly propagate the mode to the sublayers
- `forward` to implement forward pass, consisting of `x -> Linear1 -> ReLU -> Dropout -> Linear2`
- getter and setter for parameters
- simple `backward` function by calling respective method of sublayers in inverse order (commented out)

#### Tests of FeedForward-Block, including:
- bunch of invalid initializations
- verifying train/eval mode propagation
- forward shape (both 2D and 3D)
- getter and setter for parameters, as well as invalid set parameters
- veryifing reproducibility by using same seed
- different seeds

(will rebase again before merging)