### PR TITLE
Feat/encoder

### DIFF
--- a/src/encoder.py
+++ b/src/encoder.py
@@ -70,6 +70,9 @@ class Encoder(BaseLayer):
 
     def set_parameters(self, params: Dict[str, ndarray]) -> None:
         """Set parameters for the encoder, expecting namespaced keys."""
+        if not params:
+            raise ValueError("No parameters provided for Encoder.")
+
         # Prepare dicts for each block and for norm
         block_param_dicts = {name: {} for name in self.layers}
         norm_param_dict = {}

--- a/src/encoder.py
+++ b/src/encoder.py
@@ -23,8 +23,9 @@ class Encoder(BaseLayer):
         super().__init__()
         # dictionary of encoder blocks, e.g. {"encoder_block_1": EncoderBlock(...), ...}
         self.layers = layers
-        # LayerNormalization, using the d_model of the first encoder block
-        self.norm = LayerNorm(layers.values()[0].d_model)
+        # Use d_model from the first encoder block for the output LayerNorm
+        first_block = next(iter(layers.values()))
+        self.norm = LayerNorm(first_block.self_attention_block.d_model)
 
     def forward(self, x: ndarray, mask: ndarray) -> ndarray:
         """
@@ -38,7 +39,7 @@ class Encoder(BaseLayer):
             ndarray: Output data after passing through the encoder.
         """
         for layer in self.layers.values():
-            x = layer(x, mask)
+            x = layer(x, mask=mask)
         return self.norm(x)
 
     def train(self) -> None:

--- a/src/encoder.py
+++ b/src/encoder.py
@@ -1,0 +1,66 @@
+from typing import Dict
+
+from numpy import ndarray
+
+from src.layers.base import BaseLayer
+from src.layers.normalization import LayerNorm
+
+
+class Encoder(BaseLayer):
+    """
+    Encoder for the Transformer model.
+
+    Consists of multiple encoder blocks, each containing a multi-head self-attention layer, feedforward block, residual connections, and dropout.
+    """
+
+    def __init__(self, layers: Dict[str, BaseLayer]) -> None:
+        """
+        Initializes the Encoder.
+
+        Parameters:
+            layers (Dict[str, BaseLayer]): Dictionary of layers in the encoder (in sequential order).
+        """
+        super().__init__()
+        # dictionary of encoder blocks, e.g. {"encoder_block_1": EncoderBlock(...), ...}
+        self.layers = layers
+        # LayerNormalization, using the d_model of the first encoder block
+        self.norm = LayerNorm(layers.values()[0].d_model)
+
+    def forward(self, x: ndarray, mask: ndarray) -> ndarray:
+        """
+        Forward pass through the encoder.
+
+        Parameters:
+            x (ndarray): Input data.
+            mask (ndarray): Mask for the input data.
+
+        Returns:
+            ndarray: Output data after passing through the encoder.
+        """
+        for layer in self.layers.values():
+            x = layer(x, mask)
+        return self.norm(x)
+
+    def train(self) -> None:
+        """Set the layer to training mode."""
+        super().train()
+        for layer in self.layers.values():
+            layer.train()
+        self.norm.train()
+
+    def eval(self) -> None:
+        """Set the layer to evaluation mode."""
+        super().eval()
+        for layer in self.layers.values():
+            layer.eval()
+        self.norm.eval()
+
+    def get_parameters(self) -> Dict[str, ndarray]:
+        """Get all parameters from the encoder."""
+        # TODO: impmenet this method properly
+        pass
+
+    def set_parameters(self, params: Dict[str, ndarray]) -> None:
+        """Set parameters for the encoder."""
+        # TODO: implement this method properly
+        pass

--- a/src/layers/encoderblock.py
+++ b/src/layers/encoderblock.py
@@ -1,0 +1,89 @@
+from typing import Optional
+
+import numpy as np
+from numpy import ndarray
+
+from src.layers.base import BaseLayer
+from src.layers.feedforward import FeedForwardBlock
+from src.layers.multiheadattentionblock import MultiHeadAttentionBlock
+from src.layers.residual import ResidualConnection
+
+
+class EncoderBlock(BaseLayer):
+    """
+    Encoder Block for the Transformer model.
+
+    This block consists of a multi-head self-attention layer and a feed-forward neural network.
+    It also includes dropout and residual connections.
+    """
+
+    def __init__(
+        self,
+        self_attention_block: MultiHeadAttentionBlock,
+        feed_forward_block: FeedForwardBlock,
+        dropout: float,
+        seed: Optional[int],
+    ) -> None:
+        """
+        Initializes the EncoderBlock.
+
+        Parameters:
+            self_attention_block (MultiHeadAttentionBlock): The multi-head self-attention block.
+            feed_forward_block (FeedForwardBlock): The feed-forward block.
+            dropout (float): Dropout rate.
+            seed (Optional[int]): Seed for random number generator.
+        """
+        super().__init__()
+
+        if not isinstance(dropout, (int, float)) or not (0.0 <= dropout < 1.0):
+            raise ValueError("Dropout must be a float in [0.0, 1.0).")
+
+        if seed is not None and not isinstance(seed, int):
+            raise ValueError("Seed must be an integer.")
+
+        if seed is not None:
+            main_rng = np.random.default_rng(seed)
+            max_seed_val = 2**31 - 1
+            seeds = main_rng.integers(0, max_seed_val, size=2)
+            seed_residual1 = int(seeds[0])
+            seed_residual2 = int(seeds[1])
+        else:
+            seed_residual1 = None
+            seed_residual2 = None
+
+        self.self_attention_block = self_attention_block
+        self.feed_forward_block = feed_forward_block
+        # 2 reisudal connections with dropout
+        d_model = self.self_attention_block.d_model
+        eps = 1e-5
+        self.residual1 = ResidualConnection(
+            normalized_shape=d_model, eps=eps, dropout_rate=dropout, seed=seed_residual1
+        )
+        self.residual2 = ResidualConnection(
+            normalized_shape=d_model, eps=eps, dropout_rate=dropout, seed=seed_residual2
+        )
+
+    def forward(self, x: ndarray, mask: ndarray) -> ndarray:
+        """
+        Forward pass through the encoder block.
+
+        """
+        x = self.residual1(x, lambda x: self.self_attention_block(x, x, x, mask))
+        x = self.residual2(x, self.feed_forward_block)
+        return x
+
+    def train(self) -> None:
+        """Set block to training mode."""
+        super().train()
+        self.self_attention_block.train()
+        self.feed_forward_block.train()
+        self.residual1.train()
+        self.residual2.train()
+
+    def eval(self) -> None:
+        """Set block to evaluation mode."""
+        super().eval()
+        self.self_attention_block.eval()
+        self.feed_forward_block.eval()
+        self.residual1.eval()
+        self.residual2.eval()

--- a/src/layers/encoderblock.py
+++ b/src/layers/encoderblock.py
@@ -104,6 +104,9 @@ class EncoderBlock(BaseLayer):
 
     def set_parameters(self, params: Dict[str, ndarray]) -> None:
         """Set parameters for all sublayers, expecting unique prefixes."""
+        if not params:
+            raise ValueError("No parameters provided for EncoderBlock.")
+
         # Prepare a dict for each sublayer
         sublayer_param_dicts = {name: {} for name in self._layers}
         processed_keys = set()

--- a/src/layers/encoderblock.py
+++ b/src/layers/encoderblock.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 import numpy as np
 from numpy import ndarray
@@ -87,3 +87,13 @@ class EncoderBlock(BaseLayer):
         self.feed_forward_block.eval()
         self.residual1.eval()
         self.residual2.eval()
+
+    def get_parameters(self) -> Dict[str, ndarray]:
+        """Get all parameters from sublayers, with unique prefixes."""
+        # TODO: implement this method properly
+        pass
+
+    def set_parameters(self, params: Dict[str, ndarray]) -> None:
+        """Set parameters for all sublayers, expecting unique prefixes."""
+        # TODO: implement this method properly
+        pass

--- a/tests/layers/test_encoderblock.py
+++ b/tests/layers/test_encoderblock.py
@@ -1,0 +1,249 @@
+from typing import Any, Dict, Literal, Tuple
+
+import numpy as np
+import pytest
+from numpy import ndarray
+from numpy.testing import assert_allclose, assert_array_equal
+
+from src.layers.encoderblock import EncoderBlock
+from src.layers.feedforward import FeedForwardBlock
+from src.layers.multiheadattentionblock import MultiHeadAttentionBlock
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def encoderblock_config() -> Dict[str, Any]:
+    """Basic EncoderBlock configuration."""
+    return {"d_model": 16, "n_heads": 4, "d_ff": 32, "dropout": 0.1}
+
+
+@pytest.fixture
+def main_seed() -> int:
+    """Seed for reproducible tests."""
+    return 42
+
+
+@pytest.fixture
+def encoder_block(encoderblock_config: Dict[str, Any]) -> EncoderBlock:
+    """EncoderBlock without seed."""
+    attn = MultiHeadAttentionBlock(
+        d_model=encoderblock_config["d_model"],
+        n_heads=encoderblock_config["n_heads"],
+        dropout_rate=encoderblock_config["dropout"],
+        seed=None,
+    )
+    ff = FeedForwardBlock(
+        d_model=encoderblock_config["d_model"],
+        d_ff=encoderblock_config["d_ff"],
+        dropout=encoderblock_config["dropout"],
+        seed=None,
+    )
+    return EncoderBlock(
+        self_attention_block=attn,
+        feed_forward_block=ff,
+        dropout=encoderblock_config["dropout"],
+        seed=None,
+    )
+
+
+@pytest.fixture
+def encoder_block_seeded(
+    encoderblock_config: Dict[str, Any], main_seed: int
+) -> EncoderBlock:
+    """EncoderBlock with seed."""
+    # derive seeds for each layer from main seed
+    main_rng = np.random.default_rng(main_seed)
+    max_seed_val = 2**31 - 1
+    seeds = main_rng.integers(0, max_seed_val, size=3)
+    attn_seed = int(seeds[0])
+    ff_seed = int(seeds[1])
+    encoderblock_seed = int(seeds[2])
+
+    attn = MultiHeadAttentionBlock(
+        d_model=encoderblock_config["d_model"],
+        n_heads=encoderblock_config["n_heads"],
+        dropout_rate=encoderblock_config["dropout"],
+        seed=attn_seed,
+    )
+    ff = FeedForwardBlock(
+        d_model=encoderblock_config["d_model"],
+        d_ff=encoderblock_config["d_ff"],
+        dropout=encoderblock_config["dropout"],
+        seed=ff_seed,
+    )
+    return EncoderBlock(
+        self_attention_block=attn,
+        feed_forward_block=ff,
+        dropout=encoderblock_config["dropout"],
+        seed=encoderblock_seed,
+    )
+
+
+@pytest.fixture
+def sample_input(encoderblock_config: Dict[str, Any]) -> Tuple[ndarray, ndarray]:
+    """Sample input and mask for encoder block."""
+    batch_size = 2
+    seq_len = 5
+    rng = np.random.default_rng(123)
+    x = rng.standard_normal(
+        (batch_size, seq_len, encoderblock_config["d_model"])
+    ).astype(np.float32)
+    mask = np.ones(
+        (batch_size, encoderblock_config["n_heads"], seq_len, seq_len), dtype=np.float32
+    )
+    return x, mask
+
+
+# --- Test Functions ---
+
+
+def test_encoderblock_forward_shape(
+    encoder_block_seeded: EncoderBlock, sample_input: Tuple[ndarray, ndarray]
+) -> None:
+    """Test output shape matches input shape."""
+    x, mask = sample_input
+    encoder_block_seeded.train()
+    out = encoder_block_seeded(x, mask=mask)
+    assert out.shape == x.shape
+
+
+def test_encoderblock_train_eval_propagation(encoder_block: EncoderBlock) -> None:
+    """Test train/eval mode propagates to all sublayers."""
+    # Initial state (should be training)
+    assert encoder_block.training is True
+    for layer in encoder_block._layers.values():
+        assert layer.training is True
+
+    encoder_block.eval()
+    assert encoder_block.training is False
+    for layer in encoder_block._layers.values():
+        assert layer.training is False
+
+    encoder_block.train()
+    assert encoder_block.training is True
+    for layer in encoder_block._layers.values():
+        assert layer.training is True
+
+
+def test_encoderblock_get_parameters_keys(encoder_block_seeded: EncoderBlock) -> None:
+    """Test get_parameters returns expected keys."""
+    params = encoder_block_seeded.get_parameters()
+    expected_prefixes = {"self_attention_", "feed_forward_", "residual1_", "residual2_"}
+    for prefix in expected_prefixes:
+        assert any(k.startswith(prefix) for k in params), f"Missing prefix: {prefix}"
+
+
+def test_encoderblock_get_set_parameters_roundtrip(
+    encoder_block_seeded: EncoderBlock,
+) -> None:
+    """Test set_parameters restores parameters exactly."""
+    params = encoder_block_seeded.get_parameters()
+    # Modify parameters
+    new_params = {k: v + 1.0 for k, v in params.items()}
+    # set modified parameters
+    encoder_block_seeded.set_parameters(new_params)
+    params_after = encoder_block_seeded.get_parameters()
+    for k in params:
+        assert_array_equal(params_after[k], new_params[k])
+
+
+@pytest.mark.parametrize(
+    "bad_params, error_msg",
+    [
+        ({"not_a_real_param": np.ones((2, 2))}, "Unexpected parameter key"),
+        ({}, "No parameters provided for EncoderBlock"),
+        (
+            {
+                "self_attention_w_q": np.ones((2, 2)),
+                "feed_forward_w_o": np.ones((2, 2)),
+            },
+            "Expected 4 parameters: 'w_q', 'w_k', 'w_v', and 'w_o'",
+        ),
+    ],
+)
+def test_encoderblock_set_parameters_invalid(
+    encoder_block_seeded: EncoderBlock, bad_params, error_msg
+) -> None:
+    """Test set_parameters raises errors for invalid input."""
+    with pytest.raises(ValueError, match=error_msg):
+        encoder_block_seeded.set_parameters(bad_params)
+
+
+def test_encoderblock_seed_reproducibility(
+    encoderblock_config: Dict[str, Any],
+    main_seed: int,
+    sample_input: Tuple[ndarray, ndarray],
+) -> None:
+    """Test that same seed produces identical outputs."""
+    main_rng = np.random.default_rng(main_seed)
+    max_seed_val = 2**31 - 1
+    seeds = main_rng.integers(0, max_seed_val, size=3)
+    attn_seed = int(seeds[0])
+    ff_seed = int(seeds[1])
+    encoderblock_seed = int(seeds[2])
+
+    attn1 = MultiHeadAttentionBlock(
+        d_model=encoderblock_config["d_model"],
+        n_heads=encoderblock_config["n_heads"],
+        dropout_rate=encoderblock_config["dropout"],
+        seed=attn_seed,
+    )
+    ff1 = FeedForwardBlock(
+        d_model=encoderblock_config["d_model"],
+        d_ff=encoderblock_config["d_ff"],
+        dropout=encoderblock_config["dropout"],
+        seed=ff_seed,
+    )
+    block1 = EncoderBlock(attn1, ff1, encoderblock_config["dropout"], encoderblock_seed)
+
+    attn2 = MultiHeadAttentionBlock(
+        d_model=encoderblock_config["d_model"],
+        n_heads=encoderblock_config["n_heads"],
+        dropout_rate=encoderblock_config["dropout"],
+        seed=attn_seed,
+    )
+    ff2 = FeedForwardBlock(
+        d_model=encoderblock_config["d_model"],
+        d_ff=encoderblock_config["d_ff"],
+        dropout=encoderblock_config["dropout"],
+        seed=ff_seed,
+    )
+    block2 = EncoderBlock(attn2, ff2, encoderblock_config["dropout"], encoderblock_seed)
+
+    x, mask = sample_input
+    block1.eval()
+    block2.eval()
+    out1 = block1(x, mask=mask)
+    out2 = block2(x, mask=mask)
+    assert_allclose(out1, out2, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "dropout_val, error_msg",
+    [
+        (1.0, "Dropout must be a float in \\[0.0, 1.0\\)"),
+        (-0.1, "Dropout must be a float in \\[0.0, 1.0\\)"),
+        ("abc", "Dropout must be a float in \\[0.0, 1.0\\)"),
+    ],
+)
+def test_encoderblock_invalid_dropout(
+    encoderblock_config: Dict[str, Any],
+    dropout_val: float | Literal["abc"],
+    error_msg: Literal["Dropout must be a float in \\[0.0, 1.0\\)"],
+) -> None:
+    """Test invalid dropout values raise ValueError."""
+    attn = MultiHeadAttentionBlock(
+        d_model=encoderblock_config["d_model"],
+        n_heads=encoderblock_config["n_heads"],
+        dropout_rate=encoderblock_config["dropout"],
+        seed=None,
+    )
+    ff = FeedForwardBlock(
+        d_model=encoderblock_config["d_model"],
+        d_ff=encoderblock_config["d_ff"],
+        dropout=encoderblock_config["dropout"],
+        seed=None,
+    )
+    with pytest.raises(ValueError, match=error_msg):
+        EncoderBlock(attn, ff, dropout_val, None)

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,0 +1,167 @@
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import pytest
+from numpy import ndarray
+from numpy.testing import assert_allclose, assert_array_equal
+
+from src.encoder import Encoder
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def encoder_config() -> Dict[str, Any]:
+    """Basic Encoder configuration."""
+    return {"d_model": 16, "n_heads": 4, "d_ff": 32, "dropout": 0.1, "num_blocks": 3}
+
+
+@pytest.fixture
+def encoder_seed() -> int:
+    """Seed for reproducible tests."""
+    return 123
+
+
+@pytest.fixture
+def encoder(encoder_config: Dict[str, Any], encoder_seed: int) -> Encoder:
+    """Encoder built from config and seed."""
+    return Encoder.from_config(
+        d_model=encoder_config["d_model"],
+        n_heads=encoder_config["n_heads"],
+        d_ff=encoder_config["d_ff"],
+        dropout=encoder_config["dropout"],
+        num_blocks=encoder_config["num_blocks"],
+        seed=encoder_seed,
+    )
+
+
+@pytest.fixture
+def sample_encoder_input(encoder_config: Dict[str, Any]) -> Tuple[ndarray, ndarray]:
+    """Sample input and mask for encoder."""
+    batch_size = 2
+    seq_len = 5
+    rng = np.random.default_rng(456)
+    x = rng.standard_normal(
+        (batch_size, seq_len, encoder_config["d_model"])
+    )  # .astype(np.float32)
+
+    mask = np.ones(
+        (batch_size, encoder_config["n_heads"], seq_len, seq_len)  # , dtype=np.float32
+    )
+    return x, mask
+
+
+# --- Test Functions ---
+
+
+def test_encoder_forward_shape(
+    encoder: Encoder, sample_encoder_input: Tuple[ndarray, ndarray]
+) -> None:
+    """Test output shape matches input shape after all blocks and norm."""
+    x, mask = sample_encoder_input
+    encoder.train()
+    out = encoder(x, mask=mask)
+    assert out.shape == x.shape
+
+
+def test_encoder_train_eval_propagation(encoder: Encoder) -> None:
+    """Test train/eval mode propagates to all blocks and norm."""
+    assert encoder.training is True
+    for block in encoder.layers.values():
+        assert block.training is True
+    assert encoder.norm.training is True
+
+    encoder.eval()
+    assert encoder.training is False
+    for block in encoder.layers.values():
+        assert block.training is False
+    assert encoder.norm.training is False
+
+    encoder.train()
+    assert encoder.training is True
+    for block in encoder.layers.values():
+        assert block.training is True
+    assert encoder.norm.training is True
+
+
+def test_encoder_get_parameters_keys(encoder: Encoder) -> None:
+    """Test get_parameters returns all expected keys with correct prefixes."""
+    params = encoder.get_parameters()
+    expected_keys = set()
+    # Compose expected keys from all blocks and norm
+    for block_name, block in encoder.layers.items():
+        for sublayer_name, sublayer in block._layers.items():
+            for key in sublayer.get_parameters():
+                expected_keys.add(f"{block_name}_{sublayer_name}_{key}")
+    # Add norm keys
+    for key in encoder.norm.get_parameters():
+        expected_keys.add(f"norm_{key}")
+    assert set(params.keys()) == expected_keys, (
+        f"Parameter keys mismatch.\nExpected: {expected_keys}\nGot: {set(params.keys())}"
+    )
+
+
+def test_encoder_get_set_parameters_roundtrip(encoder: Encoder) -> None:
+    """Test set_parameters restores parameters exactly."""
+    params = encoder.get_parameters()
+    # Modify parameters
+    new_params = {k: v + 1.0 for k, v in params.items()}
+    encoder.set_parameters(new_params)
+    params_after = encoder.get_parameters()
+    for k in params:
+        assert_array_equal(params_after[k], new_params[k])
+
+
+@pytest.mark.parametrize(
+    "bad_params, error_msg",
+    [
+        ({"not_a_real_param": np.ones((2, 2))}, "Unexpected parameter key"),
+        ({}, "No parameters provided for Encoder"),
+        (
+            {
+                "block0_self_attention_w_q": np.ones((2, 2)),
+                "block1_feed_forward_w_o": np.ones((2, 2)),
+            },
+            "Expected 4 parameters: 'w_q', 'w_k', 'w_v', and 'w_o'",
+        ),
+    ],
+)
+def test_encoder_set_parameters_invalid(
+    encoder: Encoder, bad_params, error_msg
+) -> None:
+    """Test set_parameters raises errors for invalid input."""
+    with pytest.raises(ValueError, match=error_msg):
+        encoder.set_parameters(bad_params)
+
+
+def test_encoder_seed_reproducibility(
+    encoder_config: Dict[str, Any],
+    encoder_seed: int,
+    sample_encoder_input: Tuple[ndarray, ndarray],
+) -> None:
+    """Test that same seed produces identical outputs for all blocks."""
+    encoder1 = Encoder.from_config(
+        d_model=encoder_config["d_model"],
+        n_heads=encoder_config["n_heads"],
+        d_ff=encoder_config["d_ff"],
+        dropout=encoder_config["dropout"],
+        num_blocks=encoder_config["num_blocks"],
+        seed=encoder_seed,
+    )
+    encoder2 = Encoder.from_config(
+        d_model=encoder_config["d_model"],
+        n_heads=encoder_config["n_heads"],
+        d_ff=encoder_config["d_ff"],
+        dropout=encoder_config["dropout"],
+        num_blocks=encoder_config["num_blocks"],
+        seed=encoder_seed,
+    )
+    x, mask = sample_encoder_input
+    out1 = encoder1(x, mask=mask)
+    out2 = encoder2(x, mask=mask)
+    assert_allclose(out1, out2, rtol=1e-5, atol=1e-6)
+    encoder1.eval()
+    encoder2.eval()
+    out1_eval = encoder1(x, mask=mask)
+    out2_eval = encoder2(x, mask=mask)
+    assert_allclose(out1_eval, out2_eval, rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
This pull request implements `EncoderBlock`, `Encoder`, and testing (`test_encoder.py` and `test_encoderblock.py`).
#### `EncoderBlock`:
- `__init__` initializes the EncoderBlock, taking `self_attention_block`, `feed_forward_block`, `dropout`, and optionally a `seed`.
- `forward` implements forward pass through encoder block
- `train` & `eval` to set mode and propagate to the sublayers
- `get_parameters` & `set_parameters` to properly get and set parameters, with proper handling

#### `Encoder`:
- `__init__` method to setup `Encoder`, consisting of several `EncoderBlock`s and `LayerNorm`
- class method `from_config` to easily build an `Encoder` using `d_model`, `n_heads`, `d_ff`, `dropout`, `num_blocks`, and optionally a seed
- `forward` implements forward pass through `Encoder`, going through several `EncoderBlock`s and a `LayerNorm`
- `train` & `eval` to set mode and propagate to the sub-blocks
- `get_parameters` & `set_parameters` to properly get and set parameters, with proper handling

#### `test_encoderblock.py` includes:
- verifying forward shape
- test `train` / `eval` mode propagation
- test setter/getter (valid, invalid, roundtrip)
-  test reproducibility of seeded `EncoderBlock`

#### `test_encoder.py` includes:
- verifying forward shape
- test `train` / `eval` mode propagation
- test setter/getter (valid, invalid, roundtrip)
-  test reproducibility of seeded `Encoder`

