### PR TITLE
Feat/projection layer

### DIFF
--- a/src/layers/projection.py
+++ b/src/layers/projection.py
@@ -1,0 +1,80 @@
+from typing import Any, Dict, Optional
+
+import numpy as np
+from numpy import ndarray
+
+from src.layers.base import BaseLayer
+from src.layers.linear import Linear
+
+
+class ProjectionLayer(BaseLayer):
+    """
+    Projects output of transformer block into a probability distribution over the vocabulary.
+
+    """
+
+    def __init__(
+        self, d_model: int, vocab_size: int, seed: Optional[int] = None
+    ) -> None:
+        """
+        Initialize the projection layer.
+
+        Parameters:
+        d_model (int): Dimensionality of the model.
+        vocab_size (int): Size of the vocabulary.
+        seed (int, optional): Random seed for initialization.
+        """
+        super().__init__()
+        self.d_model = d_model
+        self.vocab_size = vocab_size
+        self.linear = Linear(d_model, vocab_size, use_bias=True, seed=seed)
+
+    def forward(self, x: ndarray, **kwargs: Any) -> ndarray:
+        """
+        Forward pass of the projection layer: Linear projection + log-softmax.
+
+        Parameters:
+        x (ndarray): Input data (output from transformer block) (..., d_model).
+
+        Returns:
+        ndarray: Log-probabilities (..., vocab_size).
+        """
+        logits = self.linear(x)
+
+        max_logits = np.max(logits, axis=-1, keepdims=True)
+        shifted = logits - max_logits
+        log_sum_exp = np.log(np.sum(np.exp(shifted), axis=-1, keepdims=True))
+        log_probs = shifted - log_sum_exp
+        return log_probs
+
+    def train(self) -> None:
+        """Set the layer to training mode."""
+        super().train()
+        self.linear.train()
+
+    def eval(self) -> None:
+        """Set the layer to evaluation mode."""
+        super().eval()
+        self.linear.eval()
+
+    def get_parameters(self) -> Dict[str, ndarray]:
+        """Get parameters of the projection layer."""
+        return {"linear_" + k: v for k, v in self.linear.get_parameters().items()}
+
+    def set_parameters(self, params: Dict[str, ndarray]) -> None:
+        """Set parameters of the projection layer."""
+        if not params:
+            raise ValueError("No parameters provided for projection layer.")
+
+        # expects keys prefixed with 'linear_', e.g. 'linear_W', 'linear_b'
+        linear_params = {}
+
+        for key, value in params.items():
+            if key.startswith("linear_"):
+                param_name = key[len("linear_") :]
+                linear_params[param_name] = value
+            else:
+                raise ValueError(f"Unexpected parameter key for ProjectionLayer: {key}")
+
+        if linear_params:
+            self.linear.set_parameters(linear_params)

--- a/tests/layers/test_projection.py
+++ b/tests/layers/test_projection.py
@@ -1,0 +1,137 @@
+import re
+from typing import Dict
+
+import numpy as np
+import pytest
+from numpy import ndarray
+from numpy.testing import assert_array_equal
+
+from src.layers.projection import ProjectionLayer
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def proj_config() -> Dict[str, int]:
+    """Basic projection layer configuration."""
+    return {"d_model": 8, "vocab_size": 20}
+
+
+@pytest.fixture
+def proj_seed() -> int:
+    """Seed for the projection layer."""
+    return 123
+
+
+@pytest.fixture
+def proj_layer(proj_config: Dict[str, int], proj_seed: int) -> ProjectionLayer:
+    """Fixture for creating a ProjectionLayer instance."""
+    return ProjectionLayer(
+        d_model=proj_config["d_model"],
+        vocab_size=proj_config["vocab_size"],
+        seed=proj_seed,
+    )
+
+
+@pytest.fixture
+def sample_input_2d(proj_config: Dict[str, int]) -> ndarray:
+    """Sample 2D input for the projection layer."""
+    rng = np.random.default_rng(42)
+    return rng.standard_normal((4, proj_config["d_model"]))  # .astype(np.float32)
+
+
+@pytest.fixture
+def sample_input_3d(proj_config: Dict[str, int]) -> ndarray:
+    """Sample 3D input for the projection layer."""
+    rng = np.random.default_rng(42)
+    return rng.standard_normal((4, 5, proj_config["d_model"]))
+
+
+# --- Tests ---
+
+
+@pytest.mark.parametrize(
+    "input_fixture",
+    ["sample_input_2d", "sample_input_3d"],
+    ids=["2D_Input", "3D_Input"],
+)
+def test_projection_layer_forward(
+    proj_layer: ProjectionLayer,
+    request: pytest.FixtureRequest,
+    input_fixture: str,
+) -> None:
+    """Test the forward pass of the projection layer."""
+    input_data = request.getfixturevalue(input_fixture)
+    output = proj_layer.forward(input_data)
+
+    # Check output shape
+    expected_shape = input_data.shape[:-1] + (proj_layer.vocab_size,)
+    assert output.shape == expected_shape, (
+        f"Expected output shape {expected_shape}, got {output.shape}"
+    )
+
+    # Check output values (log-probabilities)
+    assert np.all(np.isfinite(output)), "Output contains non-finite values."
+    assert np.all(np.isclose(np.sum(np.exp(output), axis=-1), 1)), (
+        "Output does not sum to 1 along the last dimension."
+    )
+
+
+def test_projection_get_parameters(proj_layer: ProjectionLayer) -> None:
+    params = proj_layer.get_parameters()
+    assert "linear_W" in params
+    assert "linear_b" in params
+    assert params["linear_W"].shape == (
+        proj_layer.d_model,
+        proj_layer.vocab_size,
+    )
+    assert params["linear_b"].shape == (proj_layer.vocab_size,)
+
+
+def test_projection_set_parameters_valid(proj_layer: ProjectionLayer) -> None:
+    d_model = proj_layer.d_model
+    vocab_size = proj_layer.vocab_size
+    new_W = np.random.randn(d_model, vocab_size)
+    new_b = np.random.randn(vocab_size)
+    params = {"linear_W": new_W, "linear_b": new_b}
+    proj_layer.set_parameters(params)
+    assert_array_equal(proj_layer.linear.W, new_W)
+    assert_array_equal(proj_layer.linear.b, new_b)
+
+
+@pytest.mark.parametrize(
+    "params, error_type, error_msg",
+    [
+        ({}, ValueError, "No parameters provided"),
+        ({"wrongprefix_W": np.zeros((2, 2))}, ValueError, "Unexpected parameter key"),
+        (
+            {"linear_W": np.zeros((2, 2))},
+            ValueError,
+            re.escape("Expected W shape (8, 20), but got (2, 2)"),
+        ),
+        (
+            {"linear_W": np.zeros((8, 20))},
+            ValueError,
+            "Bias parameter 'b' missing in params dictionary, but use_bias is True.",
+        ),
+        (
+            {"linear_b": np.zeros((2, 2))},
+            ValueError,
+            "Weight parameter 'W' missing in params dictionary.",
+        ),
+    ],
+)
+def test_projection_set_parameters_invalid(
+    proj_layer: ProjectionLayer, params, error_type, error_msg
+):
+    with pytest.raises(error_type, match=error_msg):
+        proj_layer.set_parameters(params)
+
+
+def test_projection_train_eval_modes(proj_layer: ProjectionLayer) -> None:
+    proj_layer.eval()
+    assert not proj_layer.training
+    assert not proj_layer.linear.training
+    proj_layer.train()
+    assert proj_layer.training
+    assert proj_layer.linear.training


### PR DESCRIPTION
This pull request implements the `ProjectionLayer`, which projects output of transformer block into probability distribution over the vocabulary by using log softmax.

#### `ProjectionLayer`:
- `__init__` initializes `Linear` layer, takes `d_model`, `vocab_size`, and optionally `seed`
- `forward` takes `x`, applies `Linear` layer to `x` and computes log softmax to obtain log probabilities
- `train` & `eval` mode
- `get_parameters` & `set_parameters` to properly get and set parameters, with some handling

#### `test_projection.py` includes:
- test forward pass
- get and set params
- train / eval mode
